### PR TITLE
Add CI: build site and all demos (with their tests) on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Same entry point the Pages deploy uses: builds every demo under
+      # demos/ (each demo's own build script, including its test suite)
+      # and then typechecks and builds the site itself.
+      - name: Build site and all demos
+        run: npm run build


### PR DESCRIPTION
Until now the repo had no PR checks — the only build ran inside the Pages deploy after merge to `main`, so a broken demo or site build was discovered post-merge.

This adds `.github/workflows/ci.yml`, triggered on every pull request (plus `workflow_dispatch`), running the exact same entry point the deploy uses: `npm ci && npm run build`. That covers **everything** in one job:

- `build:demos` auto-discovers every app under `demos/` and runs each one's own build — which for demos with test suites (e.g. `demos/grover`: `tsc --noEmit && vitest run && vite build`) runs their typecheck and tests too;
- then the site itself: `tsc -b && vite build`.

Concurrency-grouped per ref with cancel-in-progress so force-pushes don't stack runs. Read-only permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
