### PR TITLE
CI: move checkout and setup-node off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,10 +18,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
Every workflow run currently carries this annotation:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`, `actions/setup-node@v4`, `actions/upload-artifact@v4`.

`v5` of checkout and setup-node run on Node 24 natively, so this bumps both in `ci.yml` and `deploy.yml`. Same inputs, no behaviour change — and this PR's own CI run exercises both actions.

`actions/upload-artifact@v4` is pulled in transitively by `actions/upload-pages-artifact@v3` and cannot be pinned from here; that line clears when the Pages action ships its next major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)