### PR TITLE
Blast Wall Lab: live d(t) plot, and openings that land on the wall you drew them on

### DIFF
--- a/demos/blast-wall/index.html
+++ b/demos/blast-wall/index.html
@@ -72,6 +72,14 @@
       <div class="stat"><span>model</span><b id="hud-size">—</b></div>
     </div>
 
+    <figure id="trace">
+      <figcaption>
+        <span>Mid-span displacement</span>
+        <b id="trace-value">0.0 mm</b>
+      </figcaption>
+      <canvas id="trace-canvas"></canvas>
+    </figure>
+
     <div id="sheet" hidden>
       <article>
         <header>

--- a/demos/blast-wall/src/gpu/layout.ts
+++ b/demos/blast-wall/src/gpu/layout.ts
@@ -10,6 +10,9 @@
 
 import type { Mesh } from '../model/mesh.ts';
 
+/** How many (time, displacement) samples the trace ring holds. */
+export const TRACE_SAMPLES = 1024;
+
 export interface Layout {
   n: number;
   e: number;
@@ -74,6 +77,9 @@ export function layoutFor(mesh: Mesh): Layout {
   rw('nodeScalar', 2 * n);
   rw('clock', 4);
   rw('centroid', 3 * u);
+  // The displacement history of one probe node: (t, d) pairs, written by the solver
+  // itself so the curve is sampled on the simulation clock rather than on frames.
+  rw('trace', TRACE_SAMPLES * 2);
   const rwSize = c;
 
   return { n, e, p, u, u32Size, roSize, rwSize, off };
@@ -107,7 +113,12 @@ export const OFFSET_FIELDS = [
   'nodeScalar',
   'clock',
   'centroid',
+  'trace',
 ] as const;
 
-/** Bytes in the params uniform: 20 floats, 4 counts, then the offsets, padded to 16. */
-export const PARAMS_BYTES = Math.ceil((20 + 4 + OFFSET_FIELDS.length) / 4) * 4 * 4;
+/** Words after the offsets: probe node, trace stride, trace capacity. */
+export const PARAMS_TAIL = 3;
+
+/** Bytes in the params uniform: 20 floats, 4 counts, the offsets, the tail, padded to 16. */
+export const PARAMS_BYTES =
+  Math.ceil((20 + 4 + OFFSET_FIELDS.length + PARAMS_TAIL) / 4) * 4 * 4;

--- a/demos/blast-wall/src/gpu/shaders/sim.wgsl.ts
+++ b/demos/blast-wall/src/gpu/shaders/sim.wgsl.ts
@@ -32,7 +32,8 @@ struct Params {
   oLoadDir: u32, oLoadPulse: u32, oK: u32, oUnitScale: u32,
   oX: u32, oVel: u32, oQuat: u32, oElemForce: u32,
   oPairForce: u32, oPairDamage: u32, oPairState: u32, oNodeScalar: u32,
-  oClock: u32, oCentroid: u32,
+  oClock: u32, oCentroid: u32, oTrace: u32, probeNode: u32,
+  traceStride: u32, traceLen: u32,
 };
 `;
 
@@ -320,9 +321,28 @@ fn integrate(@builtin(global_invocation_id) gid: vec3<u32>) {
   RW[P.oNodeScalar + i * 2u + 1u] = length(v);
 }
 
+/**
+ * Advance the clock, and record the probe's displacement while we are here.
+ *
+ * The trace is written by the solver rather than sampled by the renderer, so the curve
+ * is spaced evenly in SIMULATION time. Sampling it per frame instead would stretch and
+ * squash the axis every time the playback speed changed, or the frame rate dipped.
+ */
 @compute @workgroup_size(1)
 fn advanceClock() {
-  RW[P.oClock] = RW[P.oClock] + P.dt;
+  let t = RW[P.oClock] + P.dt;
+  RW[P.oClock] = t;
+  let step = RW[P.oClock + 1u] + 1.0;
+  RW[P.oClock + 1u] = step;
+
+  if (u32(step) % P.traceStride != 0u) { return; }
+  let s = u32(RW[P.oClock + 2u]);
+  if (s >= P.traceLen) { return; }
+  let d = rw3(P.oX, P.probeNode) - ro3(P.oX0, P.probeNode);
+  // Out of plane is +z: the façade faces −z and the blast pushes it inward.
+  RW[P.oTrace + s * 2u] = t;
+  RW[P.oTrace + s * 2u + 1u] = d.z;
+  RW[P.oClock + 2u] = f32(s + 1u);
 }
 
 /**

--- a/demos/blast-wall/src/gpu/solver.ts
+++ b/demos/blast-wall/src/gpu/solver.ts
@@ -16,8 +16,18 @@ import type { WorldOptions } from '../physics/solver.ts';
 import { boxStiffness, maxElementFrequency } from '../physics/element.ts';
 import { buildNodeLoads } from '../physics/load.ts';
 import type { Charge } from '../physics/blast.ts';
-import { layoutFor, OFFSET_FIELDS, PARAMS_BYTES, type Layout } from './layout.ts';
+import { layoutFor, OFFSET_FIELDS, PARAMS_BYTES, TRACE_SAMPLES, type Layout } from './layout.ts';
 import { simShader } from './shaders/sim.wgsl.ts';
+
+export interface Stats {
+  /** Fraction of joints fully cracked. */
+  cracked: number;
+  maxSpeed: number;
+  /** Fraction of nodes moving faster than 0.5 m/s. */
+  flying: number;
+  /** Interleaved (time, displacement) pairs for the probe node. */
+  trace: Float32Array;
+}
 
 export class GpuSolver {
   readonly device: GPUDevice;
@@ -47,6 +57,8 @@ export class GpuSolver {
   private readonly buildDensity: number;
   /** Live nodal inverse masses, rescaled whenever the density changes. */
   private readonly invMass: F32;
+  /** The node whose displacement history the d(t) plot shows. */
+  readonly probeNode: number;
   private staging: GPUBuffer | null = null;
   private statsPending = false;
 
@@ -66,6 +78,7 @@ export class GpuSolver {
     this.nodeMass = (materials.density * mesh.dx * mesh.dy * mesh.dz) / 8;
     this.buildDensity = materials.density;
     this.invMass = Float32Array.from(mesh.invMass);
+    this.probeNode = findProbeNode(mesh);
 
     const L = this.layout;
     const adj = buildAdjacency(mesh);
@@ -233,6 +246,12 @@ export class GpuSolver {
     OFFSET_FIELDS.forEach((name, i) => {
       u[24 + i] = this.layout.off[name];
     });
+    const tail = 24 + OFFSET_FIELDS.length;
+    u[tail] = this.probeNode;
+    // Aim the trace at roughly a full ring over the length of a blast event, so the
+    // curve is dense without the recording kernel running every single step.
+    u[tail + 1] = Math.max(1, Math.round(0.35 / this.dt / TRACE_SAMPLES));
+    u[tail + 2] = TRACE_SAMPLES;
     this.device.queue.writeBuffer(this.params, 0, this.paramBytes);
   }
 
@@ -273,22 +292,32 @@ export class GpuSolver {
    * Called a few times a second, not every frame: it is the only place the CPU looks at
    * the solver's state, and "34 % of joints cracked" is worth one small copy.
    */
-  async readStats(): Promise<{ cracked: number; maxSpeed: number; flying: number } | null> {
+  async readStats(): Promise<Stats | null> {
     if (this.statsPending) return null;
     this.statsPending = true;
     const L = this.layout;
     const damageBytes = L.p * 4;
     const scalarBytes = L.n * 2 * 4;
+    const clockBytes = 16;
+    const traceBytes = TRACE_SAMPLES * 2 * 4;
     if (!this.staging) {
       this.staging = this.device.createBuffer({
         label: 'stats staging',
-        size: damageBytes + scalarBytes,
+        size: damageBytes + scalarBytes + clockBytes + traceBytes,
         usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
       });
     }
     const encoder = this.device.createCommandEncoder();
     encoder.copyBufferToBuffer(this.rw, L.off.pairDamage * 4, this.staging, 0, damageBytes);
     encoder.copyBufferToBuffer(this.rw, L.off.nodeScalar * 4, this.staging, damageBytes, scalarBytes);
+    encoder.copyBufferToBuffer(this.rw, L.off.clock * 4, this.staging, damageBytes + scalarBytes, clockBytes);
+    encoder.copyBufferToBuffer(
+      this.rw,
+      L.off.trace * 4,
+      this.staging,
+      damageBytes + scalarBytes + clockBytes,
+      traceBytes,
+    );
     this.device.queue.submit([encoder.finish()]);
     try {
       await this.staging.mapAsync(GPUMapMode.READ);
@@ -304,7 +333,15 @@ export class GpuSolver {
         if (s > maxSpeed) maxSpeed = s;
         if (s > 0.5) flying++;
       }
-      return { cracked: cracked / Math.max(L.p, 1), maxSpeed, flying: flying / Math.max(L.n, 1) };
+      // The trace ring: (t, d) pairs the solver wrote on its own clock.
+      const traceBase = L.p + L.n * 2 + 4;
+      const samples = Math.min(view[L.p + L.n * 2 + 2] | 0, TRACE_SAMPLES);
+      return {
+        cracked: cracked / Math.max(L.p, 1),
+        maxSpeed,
+        flying: flying / Math.max(L.n, 1),
+        trace: view.subarray(traceBase, traceBase + samples * 2),
+      };
     } catch {
       return null;
     } finally {
@@ -324,6 +361,30 @@ export class GpuSolver {
   flushReadOnly(): void {
     this.device.queue.writeBuffer(this.ro, 0, this.roData);
   }
+}
+
+/**
+ * Where to put the displacement gauge: the middle of the loaded face.
+ *
+ * A real blast test puts a transducer at mid-span, because that is where a one-way
+ * spanning panel moves most and where the textbook single-degree-of-freedom solution
+ * applies. Taking a maximum over the whole façade instead would track whichever brick
+ * happens to be flying fastest, which is a different and much less readable quantity.
+ */
+function findProbeNode(mesh: Mesh): number {
+  const targetX = mesh.lattice.length / 2;
+  const targetY = mesh.lattice.height / 2;
+  let best = 0;
+  let bestD = Infinity;
+  for (let n = 0; n < mesh.nodeCount; n++) {
+    if (mesh.x0[n * 3 + 2] > 1e-6) continue; // the outer face of the loaded wall
+    const d = Math.hypot(mesh.x0[n * 3] - targetX, mesh.x0[n * 3 + 1] - targetY);
+    if (d < bestD) {
+      bestD = d;
+      best = n;
+    }
+  }
+  return best;
 }
 
 function groups(count: number): number {

--- a/demos/blast-wall/src/main.ts
+++ b/demos/blast-wall/src/main.ts
@@ -611,13 +611,22 @@ function drawOverlay(): void {
   if (!r) return;
   const rect = canvas.getBoundingClientRect();
   const aspect = rect.width / Math.max(rect.height, 1);
+  // The band lives in its own wall's plane, so lift its two in-plane coordinates back
+  // into world space according to which wall that is.
+  const lat = mesh.lattice;
+  const onZ = r.face === 'z0' || r.face === 'z1';
+  const plane =
+    r.face === 'z0' ? 0 : r.face === 'z1' ? lat.thickness : r.face === 'x0' ? 0 : lat.length;
+  const world = (along: number, y: number): [number, number, number] =>
+    onZ ? [along, y, plane] : [plane, y, along];
+
   const pts = [
     [r.x, r.y],
     [r.x + r.w, r.y],
     [r.x + r.w, r.y + r.h],
     [r.x, r.y + r.h],
   ]
-    .map(([x, y]) => camera.project([x, y, 0], aspect, rect.width, rect.height))
+    .map(([a, y]) => camera.project(world(a, y), aspect, rect.width, rect.height))
     .map(([px, py]) => `${px.toFixed(1)},${py.toFixed(1)}`)
     .join(' ');
   const poly = document.createElementNS('http://www.w3.org/2000/svg', 'polygon');

--- a/demos/blast-wall/src/main.ts
+++ b/demos/blast-wall/src/main.ts
@@ -34,6 +34,7 @@ import { OrbitCamera } from './render/camera.ts';
 import { Panel, type Group } from './ui/controls.ts';
 import { Editor, type Tool } from './ui/editor.ts';
 import { Sheet } from './ui/sheet.ts';
+import { TracePlot } from './ui/trace.ts';
 
 // Divisions through the thickness are derived (nx / 2), because the lattice has to stay
 // square in plan for the corners of a room to bond. See `latticeFor`.
@@ -61,6 +62,7 @@ state.charge = { ...defaultCharge(), x: 1.8, y: 1.0, z: -4.5, mass: 25 };
 const canvas = document.getElementById('view') as HTMLCanvasElement;
 const overlay = document.getElementById('overlay') as unknown as SVGSVGElement;
 const camera = new OrbitCamera();
+const trace = new TracePlot(document.getElementById('trace-canvas') as HTMLCanvasElement);
 
 let mesh: Mesh;
 let solver: GpuSolver;
@@ -100,6 +102,7 @@ function rebuild(): void {
   // Editing mid-flight would silently restart the run on the new geometry, which reads
   // as the wall teleporting. Stop, so an edit is something you make and then fire.
   state.playing = false;
+  trace.reset();
   const pp = document.getElementById('playpause');
   if (pp) pp.textContent = 'Play';
 }
@@ -572,6 +575,8 @@ function frame(now: number): void {
       if (!s) return;
       el('hud-cracked').textContent = `${(s.cracked * 100).toFixed(1)} %`;
       el('hud-speed').textContent = `${s.maxSpeed.toFixed(1)} m/s`;
+      trace.update(s.trace);
+      el('trace-value').textContent = `${trace.latest().toFixed(1)} mm`;
     });
   }
 
@@ -638,6 +643,7 @@ async function boot(): Promise<void> {
 
   el('detonate').addEventListener('click', () => {
     solver.reset();
+    trace.reset();
     state.playing = true;
     el('playpause').textContent = 'Pause';
     setStatus('Firing. The front leaves the charge at several times the speed of sound and slows as it goes.');
@@ -648,6 +654,7 @@ async function boot(): Promise<void> {
   });
   el('reset').addEventListener('click', () => {
     solver.reset();
+    trace.reset();
     state.playing = false;
     el('playpause').textContent = 'Play';
     setStatus('Wall rebuilt, undamaged, at rest.');

--- a/demos/blast-wall/src/model/bond.ts
+++ b/demos/blast-wall/src/model/bond.ts
@@ -14,7 +14,7 @@
  * bond at their corners. See `latticeFor`.
  */
 
-import { brickThickness, type WallSpec } from './types.ts';
+import { brickThickness, type FaceName, type WallSpec } from './types.ts';
 
 export interface Unit {
   /** Stable id across re-generation, "course:latticeX:latticeZ". */
@@ -228,7 +228,7 @@ function layRun(
 
       const key = `${course}:${ix0}:${iz0}`;
       if (ctx.removed.has(key)) continue;
-      if (insideOpening(spec, lat, ix0, ix1, iy0, iy0 + lat.uy, iz0)) continue;
+      if (insideOpening(spec, lat, { ix0, ix1, iy0, iy1: iy0 + lat.uy, iz0, iz1 })) continue;
       ctx.units.push({
         key,
         course,
@@ -252,21 +252,48 @@ function layRun(
  * Openings are drawn on the face nearest the charge, so they only cut the wall they were
  * drawn on — otherwise every window would come with a matching hole in the back wall.
  */
-function insideOpening(
-  spec: WallSpec,
-  lat: Lattice,
-  ix0: number,
-  ix1: number,
-  iy0: number,
-  iy1: number,
-  iz0: number,
-): boolean {
+/** Anything with lattice extents: a unit, or a candidate cell being tested. */
+export interface Box {
+  ix0: number;
+  ix1: number;
+  iy0: number;
+  iy1: number;
+  iz0: number;
+  iz1: number;
+}
+
+/**
+ * Which of a room's walls a unit belongs to, or null if it is not on one — which for a
+ * single wall is everything, and that is what makes `face` meaningless there.
+ */
+export function faceOf(lat: Lattice, b: Box): FaceName | null {
+  if (b.iz0 < lat.wall) return 'z0';
+  if (b.iz1 > lat.nz - lat.wall) return 'z1';
+  if (b.ix0 < lat.wall) return 'x0';
+  if (b.ix1 > lat.nx - lat.wall) return 'x1';
+  return null;
+}
+
+/**
+ * A unit is cut away by an opening when its centre falls inside one.
+ *
+ * An opening belongs to the wall it was drawn on, and only cuts that one — otherwise
+ * every window comes with a matching hole in the wall opposite. The in-plane coordinate
+ * runs along the wall itself: x for the front and back, z for the returns, so a window
+ * dragged on a return wall means what it looked like it meant.
+ */
+function insideOpening(spec: WallSpec, lat: Lattice, b: Box): boolean {
   if (spec.openings.length === 0) return false;
-  // Cut only the wall the opening was drawn on, or every window would come with a
-  // matching hole in the back wall. Compare against the façade's whole thickness, not
-  // just its outer leaf — keying on iz0 === 0 left a solid inner leaf behind the hole.
-  if (spec.plan === 'room' && iz0 >= lat.wall) return false;
-  const cx = ((ix0 + ix1) / 2) * lat.dx;
-  const cy = ((iy0 + iy1) / 2) * lat.dy;
-  return spec.openings.some((o) => cx > o.x && cx < o.x + o.w && cy > o.y && cy < o.y + o.h);
+  const cy = ((b.iy0 + b.iy1) / 2) * lat.dy;
+  const wall = spec.plan === 'room' ? faceOf(lat, b) : 'z0';
+  if (wall === null) return false;
+  const along =
+    wall === 'x0' || wall === 'x1'
+      ? ((b.iz0 + b.iz1) / 2) * lat.dz
+      : ((b.ix0 + b.ix1) / 2) * lat.dx;
+
+  return spec.openings.some((o) => {
+    if (spec.plan === 'room' && (o.face ?? 'z0') !== wall) return false;
+    return along > o.x && along < o.x + o.w && cy > o.y && cy < o.y + o.h;
+  });
 }

--- a/demos/blast-wall/src/model/types.ts
+++ b/demos/blast-wall/src/model/types.ts
@@ -30,13 +30,24 @@ export type SupportName = 'base' | 'base-top' | 'three-sided' | 'four-sided' | '
 /** A single wall standing on its own, or four of them bonded into a room. */
 export type PlanName = 'wall' | 'room';
 
+/**
+ * Which of a room's four walls something belongs to, named by the face it sits on:
+ * z0 is the wall nearest the charge, x0 and x1 the returns.
+ */
+export type FaceName = 'z0' | 'z1' | 'x0' | 'x1';
+
 export interface Opening {
-  /** Left edge, metres from the wall's left end. */
+  /**
+   * Left edge, metres along the wall's own run direction — x for the front and back
+   * walls, z for the returns.
+   */
   x: number;
   /** Bottom edge, metres above the base. */
   y: number;
   w: number;
   h: number;
+  /** The wall it was cut in. Absent means the front wall, for older saved specs. */
+  face?: FaceName;
 }
 
 export interface WallSpec {

--- a/demos/blast-wall/src/style.css
+++ b/demos/blast-wall/src/style.css
@@ -136,17 +136,55 @@ html, body {
 .tool.active { color: #14100d; background: var(--cool); border-color: var(--cool); font-weight: 600; }
 
 #reads { display: flex; gap: 6px; }
+/* Not ghosted: the first version of these was faint enough that people looked straight
+   past the Theory button and concluded the demo had no theory. */
 .btn.ghost {
-  padding: 6px 10px;
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--muted);
-  background: transparent;
-  border-color: var(--edge);
+  padding: 7px 10px;
+  font-size: 12.5px;
+  font-weight: 550;
+  color: var(--cool);
+  background: rgba(88, 183, 214, 0.1);
+  border-color: rgba(88, 183, 214, 0.4);
 }
-.btn.ghost:hover { color: var(--ink); background: rgba(255, 255, 255, 0.06); }
+.btn.ghost:hover { background: rgba(88, 183, 214, 0.2); }
 
 #groups { display: flex; flex-direction: column; gap: 6px; }
+
+/* ---- d(t) plot ---- */
+
+#trace {
+  position: fixed;
+  right: 14px;
+  bottom: 14px;
+  z-index: 10;
+  margin: 0;
+  width: 300px;
+  padding: 10px 12px 6px;
+  background: var(--panel);
+  backdrop-filter: blur(14px);
+  border: 1px solid var(--edge);
+  border-radius: 10px;
+}
+#trace figcaption {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 4px;
+}
+#trace figcaption span {
+  font-size: 10.5px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+#trace figcaption b {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+#trace-canvas { display: block; width: 100%; height: 96px; }
 
 /* ---- the guide / theory sheet ---- */
 

--- a/demos/blast-wall/src/ui/editor.ts
+++ b/demos/blast-wall/src/ui/editor.ts
@@ -13,7 +13,8 @@
  */
 
 import type { Mesh } from '../model/mesh.ts';
-import type { WallSpec } from '../model/types.ts';
+import { faceOf } from '../model/bond.ts';
+import type { FaceName, WallSpec } from '../model/types.ts';
 import type { Charge } from '../physics/blast.ts';
 import type { OrbitCamera, Vec3 } from '../render/camera.ts';
 
@@ -37,15 +38,16 @@ interface Drag {
   x: number;
   y: number;
   moved: number;
-  /** Wall-plane anchor for a rubber-banded opening. */
+  /** Wall-plane anchor for a rubber-banded opening, and the wall it started on. */
   anchor?: [number, number];
+  face?: FaceName;
 }
 
 export class Editor {
   tool: Tool = 'select';
   selection = new Set<number>();
-  /** Live rubber band in wall coordinates, for the overlay. */
-  rubber: { x: number; y: number; w: number; h: number } | null = null;
+  /** Live rubber band in the coordinates of the wall it is being dragged on. */
+  rubber: { x: number; y: number; w: number; h: number; face: FaceName } | null = null;
 
   private drag: Drag | null = null;
 
@@ -87,10 +89,10 @@ export class Editor {
     }
 
     if (this.tool === 'opening') {
-      const p = this.wallPlanePoint(origin, dir);
+      const p = this.wallHit(origin, dir);
       if (p) {
-        this.drag = { ...base, mode: 'opening', anchor: p };
-        this.rubber = { x: p[0], y: p[1], w: 0, h: 0 };
+        this.drag = { ...base, mode: 'opening', anchor: [p.along, p.y], face: p.face };
+        this.rubber = { x: p.along, y: p.y, w: 0, h: 0, face: p.face };
         return;
       }
     }
@@ -136,13 +138,16 @@ export class Editor {
       }
       case 'opening': {
         const { origin, dir } = this.ray(e);
-        const p = this.wallPlanePoint(origin, dir);
-        if (p && d.anchor) {
+        const p = this.wallHit(origin, dir);
+        // Dragging onto a different wall mid-gesture keeps the rectangle on the one it
+        // started on, rather than jumping the opening around the room.
+        if (p && d.anchor && p.face === d.face) {
           this.rubber = {
-            x: Math.min(d.anchor[0], p[0]),
-            y: Math.min(d.anchor[1], p[1]),
-            w: Math.abs(p[0] - d.anchor[0]),
-            h: Math.abs(p[1] - d.anchor[1]),
+            x: Math.min(d.anchor[0], p.along),
+            y: Math.min(d.anchor[1], p.y),
+            w: Math.abs(p.along - d.anchor[0]),
+            h: Math.abs(p.y - d.anchor[1]),
+            face: p.face,
           };
         }
         break;
@@ -263,6 +268,10 @@ export class Editor {
   /** Nearest unit along the ray, or −1. */
   private pick(e: PointerEvent): number {
     const { origin, dir } = this.ray(e);
+    return this.pickRay(origin, dir);
+  }
+
+  private pickRay(origin: Vec3, dir: Vec3): number {
     // Pointer handlers are live before the first mesh exists — the loading overlay
     // usually swallows the click, but a click during WebGPU bring-up would land here.
     const mesh = this.host.mesh() as Mesh | undefined;
@@ -286,18 +295,36 @@ export class Editor {
     return best;
   }
 
-  /** Where the ray meets the wall's outer face, in wall coordinates. */
-  private wallPlanePoint(origin: Vec3, dir: Vec3): [number, number] | null {
-    if (Math.abs(dir[2]) < 1e-6) return null;
-    const t = (0 - origin[2]) / dir[2];
-    if (t <= 0) return null;
+  /**
+   * Where the ray meets a wall, and WHICH wall.
+   *
+   * The first version of this always intersected the plane z = 0, so a rectangle dragged
+   * on the near wall of a room was cut out of the far one. Find the wall under the cursor
+   * first, then intersect that wall's own outer plane, and report the coordinate along
+   * the wall rather than a world axis.
+   */
+  private wallHit(origin: Vec3, dir: Vec3): { along: number; y: number; face: FaceName } | null {
     const mesh = this.host.mesh() as Mesh | undefined;
     if (!mesh) return null;
     const lat = mesh.lattice;
-    const x = origin[0] + dir[0] * t;
-    const y = origin[1] + dir[1] * t;
-    if (x < -0.5 || x > lat.length + 0.5 || y < -0.5 || y > lat.height + 0.5) return null;
-    return [x, y];
+
+    const unit = this.pickRay(origin, dir);
+    if (unit < 0) return null;
+    const face = this.host.spec().plan === 'room' ? faceOf(lat, mesh.units[unit]) : 'z0';
+    if (!face) return null;
+
+    const axis = face === 'z0' || face === 'z1' ? 2 : 0;
+    const plane =
+      face === 'z0' ? 0 : face === 'z1' ? lat.nz * lat.dz : face === 'x0' ? 0 : lat.nx * lat.dx;
+    if (Math.abs(dir[axis]) < 1e-6) return null;
+    const t = (plane - origin[axis]) / dir[axis];
+    if (t <= 0) return null;
+
+    const p: Vec3 = [origin[0] + dir[0] * t, origin[1] + dir[1] * t, origin[2] + dir[2] * t];
+    const along = axis === 2 ? p[0] : p[2];
+    const span = axis === 2 ? lat.length : lat.thickness;
+    if (along < -0.5 || along > span + 0.5 || p[1] < -0.5 || p[1] > lat.height + 0.5) return null;
+    return { along, y: p[1], face };
   }
 }
 

--- a/demos/blast-wall/src/ui/sheet.ts
+++ b/demos/blast-wall/src/ui/sheet.ts
@@ -53,8 +53,10 @@ const GUIDE = /* html */ `
 </ol>
 
 <p class="foot">
-  Drag to orbit · scroll to zoom · shift-drag to pan. The numbers top-right are live:
-  scaled distance Z, peak reflected pressure, the fraction of joints fully cracked.
+  Drag to orbit · scroll to zoom · shift-drag to pan. The numbers top-right are live, and
+  the plot bottom-right is the displacement of the middle of the loaded wall against
+  time — the trace a real blast test records. For the maths behind all of it, the
+  <b>Theory</b> button sits next to the one that opened this.
 </p>
 `;
 

--- a/demos/blast-wall/src/ui/trace.ts
+++ b/demos/blast-wall/src/ui/trace.ts
@@ -1,0 +1,118 @@
+/**
+ * The d(t) plot: how far the middle of the loaded wall has moved, against time.
+ *
+ * This is the trace a real blast test produces — a displacement transducer at mid-span —
+ * and it is the one picture that separates "the wall rang and came back" from "the wall
+ * went and kept going". The samples come off the solver's own clock, so the horizontal
+ * axis is simulation time and does not stretch when the playback speed changes.
+ */
+
+const PAD = { l: 40, r: 10, t: 10, b: 20 };
+
+export class TracePlot {
+  private readonly canvas: HTMLCanvasElement;
+  private readonly ctx: CanvasRenderingContext2D;
+  private data: Float32Array = new Float32Array(0);
+  /** Range seen so far, so the axis grows but never shrinks mid-event. */
+  private lo = 0;
+  private hi = 0;
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d')!;
+  }
+
+  reset(): void {
+    this.data = new Float32Array(0);
+    this.lo = 0;
+    this.hi = 0;
+    this.draw();
+  }
+
+  update(trace: Float32Array): void {
+    this.data = trace;
+    for (let i = 1; i < trace.length; i += 2) {
+      this.lo = Math.min(this.lo, trace[i]);
+      this.hi = Math.max(this.hi, trace[i]);
+    }
+    this.draw();
+  }
+
+  /** Latest displacement in millimetres, for the readout. */
+  latest(): number {
+    return this.data.length >= 2 ? this.data[this.data.length - 1] * 1000 : 0;
+  }
+
+  draw(): void {
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    const w = Math.max(1, Math.floor(this.canvas.clientWidth * dpr));
+    const h = Math.max(1, Math.floor(this.canvas.clientHeight * dpr));
+    if (this.canvas.width !== w || this.canvas.height !== h) {
+      this.canvas.width = w;
+      this.canvas.height = h;
+    }
+    const c = this.ctx;
+    const style = getComputedStyle(document.documentElement);
+    const muted = style.getPropertyValue('--muted').trim() || '#8e96a2';
+    const accent = style.getPropertyValue('--accent').trim() || '#e2703a';
+    const edge = 'rgba(255,255,255,0.12)';
+
+    c.setTransform(dpr, 0, 0, dpr, 0, 0);
+    c.clearRect(0, 0, w, h);
+    const iw = this.canvas.clientWidth - PAD.l - PAD.r;
+    const ih = this.canvas.clientHeight - PAD.t - PAD.b;
+
+    // Time axis spans the event, not just what has been recorded, so the curve draws
+    // itself across a stable frame instead of rescaling on every sample.
+    const tEnd = Math.max(0.05, this.data.length >= 2 ? this.data[this.data.length - 2] : 0.05);
+    // Scale to the range actually reached, keeping zero on the axis. A symmetric axis
+    // wastes half the plot whenever the wall only ever goes one way, which is most of
+    // the time — the blast pushes, it does not pull it back through zero.
+    const span = Math.max(this.hi - this.lo, 0.002);
+    const top = this.hi + span * 0.12;
+    const bot = this.lo - span * 0.12;
+
+    const x = (t: number) => PAD.l + (t / tEnd) * iw;
+    const y = (d: number) => PAD.t + ((top - d) / (top - bot)) * ih;
+
+    c.strokeStyle = edge;
+    c.lineWidth = 1;
+    c.beginPath();
+    c.moveTo(PAD.l, y(0));
+    c.lineTo(PAD.l + iw, y(0));
+    c.moveTo(PAD.l, PAD.t);
+    c.lineTo(PAD.l, PAD.t + ih);
+    c.stroke();
+
+    c.fillStyle = muted;
+    c.font = '9px ui-monospace, Menlo, monospace';
+    c.textAlign = 'right';
+    c.fillText(`${(top * 1000).toFixed(0)}`, PAD.l - 4, PAD.t + 8);
+    // Only label zero when it is not sitting on top of one of the ends.
+    if (y(0) > PAD.t + 16 && y(0) < PAD.t + ih - 10) c.fillText('0', PAD.l - 4, y(0) + 3);
+    c.fillText(`${(bot * 1000).toFixed(0)}`, PAD.l - 4, PAD.t + ih);
+    c.fillText(`${(tEnd * 1000).toFixed(0)} ms`, PAD.l + iw, PAD.t + ih + 14);
+
+    if (this.data.length < 4) return;
+
+    c.strokeStyle = accent;
+    c.lineWidth = 1.6;
+    c.lineJoin = 'round';
+    c.beginPath();
+    for (let i = 0; i < this.data.length; i += 2) {
+      const px = x(this.data[i]);
+      const py = y(this.data[i + 1]);
+      if (i === 0) c.moveTo(px, py);
+      else c.lineTo(px, py);
+    }
+    c.stroke();
+
+    // Mark where it is now, since the curve is still being written.
+    const lastX = x(this.data[this.data.length - 2]);
+    const lastY = y(this.data[this.data.length - 1]);
+    c.fillStyle = accent;
+    c.beginPath();
+    c.arc(lastX, lastY, 2.4, 0, Math.PI * 2);
+    c.fill();
+  }
+}

--- a/demos/blast-wall/tools/selftest.ts
+++ b/demos/blast-wall/tools/selftest.ts
@@ -625,6 +625,29 @@ function testRoom(): void {
     );
   }
 
+  // An opening belongs to the wall it was drawn on. Cutting one out of a return wall
+  // used to punch it through the façade instead, because the editor always intersected
+  // the plane z = 0 and the mesher only ever cut units with iz0 === 0.
+  {
+    const cut: WallSpec = {
+      ...spec,
+      openings: [{ x: 0.4, y: 0.2, w: 0.6, h: 0.5, face: 'x0' }],
+    };
+    const before = buildMesh(spec, mat.density);
+    const after = buildMesh(cut, mat.density);
+    const onWall = (m: typeof before, face: 'x0' | 'z0') =>
+      m.units.filter((u) =>
+        face === 'x0' ? u.ix0 < m.lattice.wall : u.iz0 < m.lattice.wall,
+      ).length;
+    const lostReturn = onWall(before, 'x0') - onWall(after, 'x0');
+    const lostFacade = onWall(before, 'z0') - onWall(after, 'z0');
+    check(
+      'an opening cuts the wall it was drawn on and no other',
+      lostReturn > 0 && lostFacade === 0,
+      `${lostReturn} bricks gone from the return wall, ${lostFacade} from the façade`,
+    );
+  }
+
   check(
     'return walls hold the ends of the façade that a lone wall cannot',
     inRoom < alone * 0.6,


### PR DESCRIPTION
Follow-up to #28.

## A d(t) plot, live while it runs

A displacement gauge at the middle of the loaded wall, plotted against time — the trace a real blast test records, and the one picture that separates "the wall rang and came back" from "the wall went and kept going".

The samples are written by the **solver**, in `advanceClock`, not sampled by the renderer. Sampled per frame the horizontal axis would stretch and squash every time the playback speed changed or the frame rate dipped; written on the simulation clock it is evenly spaced in simulated milliseconds whatever the display is doing. The recording kernel runs every Nth step, N chosen so a 1024-sample ring spans roughly a whole blast event, and the ring rides back on the stats readback that was already happening 4×/second.

The probe sits at mid-span of the loaded face, where a real transducer goes and where the SDOF solution applies. A maximum over the whole façade would track whichever brick happens to be flying fastest — a different, much less readable quantity.

**Checked at both ends before believing it:**
- Backed off to Z = 68 m/kg^⅓ (2 kPa): the wall rings at **0.7 mm**, changes sign, settles. Elastic response.
- At the default 25 kg / 4.5 m the mid-span brick separates and the trace goes ballistic at ~4 m/s, decelerating under damping and gravity.

The axis scales to the range actually reached rather than symmetrically about zero — the blast pushes and does not pull the wall back through zero, so a symmetric axis wasted half the plot.

## Openings landed on the wrong wall

Dragging a window on one wall of a room put the hole in a different one. Two causes, both left over from the single-wall days: the editor always intersected the plane `z = 0` whatever was under the cursor, and the mesher only cut units with `iz0 === 0`. On a room, `z = 0` is the wall nearest the charge — from most camera angles, the far one.

Openings now record which wall they belong to, with the in-plane coordinate running along that wall (x for front and back, z for the returns). The editor picks the brick under the cursor, asks which face it sits on, and intersects *that* wall's plane. Dragging onto another wall mid-gesture keeps the rectangle where it started. `face` is optional and absent means the front wall, so older specs still mean what they meant.

## Also

The Guide and Theory buttons were ghost-styled enough to read as chrome — the theory got reported as missing while sitting in plain sight. Solid cyan now, and the guide's closing line names the Theory button.

## Tests

27 checks, all green. New: an opening on a return wall takes 15 bricks out of that wall and **0** out of the façade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
