### PR TITLE
Blast Wall Lab: typeset the theory with KaTeX, as the other demos do

### DIFF
--- a/demos/blast-wall/package-lock.json
+++ b/demos/blast-wall/package-lock.json
@@ -7,7 +7,11 @@
     "": {
       "name": "blast-wall",
       "version": "1.0.0",
+      "dependencies": {
+        "katex": "^0.16.11"
+      },
       "devDependencies": {
+        "@types/katex": "^0.16.8",
         "@types/node": "^24.0.0",
         "@webgpu/types": "^0.1.64",
         "tsx": "^4.19.0",
@@ -873,6 +877,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.13.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
@@ -889,6 +900,15 @@
       "integrity": "sha512-0cF7RFM2edNoiIS1ODJp0/Gzv4/xSXhwoR0YCza+OWpJWtn4wmo9DvK91aLlH9+uUnwIriP7ZiC3WitmyhuzBw==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.28.2",
@@ -963,6 +983,22 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/nanoid": {

--- a/demos/blast-wall/package.json
+++ b/demos/blast-wall/package.json
@@ -11,7 +11,11 @@
     "typecheck": "tsc --noEmit",
     "selftest": "tsx tools/selftest.ts"
   },
+  "dependencies": {
+    "katex": "^0.16.11"
+  },
   "devDependencies": {
+    "@types/katex": "^0.16.8",
     "@types/node": "^24.0.0",
     "@webgpu/types": "^0.1.64",
     "tsx": "^4.19.0",

--- a/demos/blast-wall/src/main.ts
+++ b/demos/blast-wall/src/main.ts
@@ -34,6 +34,7 @@ import { OrbitCamera } from './render/camera.ts';
 import { Panel, type Group } from './ui/controls.ts';
 import { Editor, type Tool } from './ui/editor.ts';
 import { Sheet } from './ui/sheet.ts';
+import { createExplainer } from './ui/explainer.ts';
 import { TracePlot } from './ui/trace.ts';
 
 // Divisions through the thickness are derived (nx / 2), because the lattice has to stay
@@ -670,8 +671,9 @@ async function boot(): Promise<void> {
   });
 
   const sheet = new Sheet();
+  const explainer = createExplainer();
   el('open-guide').addEventListener('click', () => sheet.open('guide'));
-  el('open-theory').addEventListener('click', () => sheet.open('theory'));
+  el('open-theory').addEventListener('click', () => void explainer.open());
 
   document.getElementById('loading')?.remove();
   sheet.openIfFirstVisit();

--- a/demos/blast-wall/src/style.css
+++ b/demos/blast-wall/src/style.css
@@ -186,7 +186,100 @@ html, body {
 }
 #trace-canvas { display: block; width: 100%; height: 96px; }
 
-/* ---- the guide / theory sheet ---- */
+/* ---- the typeset theory paper ---- */
+
+#explainer {
+  width: min(46rem, calc(100vw - 2rem));
+  max-height: min(88vh, 62rem);
+  margin: auto;
+  padding: 0;
+  border: 1px solid var(--edge-strong);
+  border-radius: 14px;
+  background: #12151a;
+  color: var(--ink);
+  overflow: hidden;
+}
+#explainer::backdrop { background: rgba(6, 7, 9, 0.74); backdrop-filter: blur(3px); }
+
+#explainer article {
+  max-height: min(88vh, 62rem);
+  overflow-y: auto;
+  padding: 2.4rem 2.8rem 3rem;
+  scrollbar-width: thin;
+}
+
+.explainer-close {
+  position: absolute;
+  top: 0.7rem;
+  right: 0.9rem;
+  z-index: 2;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  font: inherit;
+  font-size: 1.2rem;
+  line-height: 1;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--edge);
+  border-radius: 50%;
+  cursor: pointer;
+}
+.explainer-close:hover { color: var(--ink); background: rgba(255, 255, 255, 0.11); }
+
+#explainer h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 1.22;
+  letter-spacing: -0.018em;
+  text-wrap: balance;
+}
+#explainer .byline {
+  margin: 0.5rem 0 0;
+  font-size: 0.8rem;
+  font-style: italic;
+  color: var(--muted);
+}
+#explainer section { margin-top: 2rem; }
+#explainer h2 {
+  margin: 0 0 0.7rem;
+  font-size: 0.72rem;
+  font-weight: 650;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+#explainer p,
+#explainer li {
+  margin: 0 0 0.95rem;
+  font-size: 0.87rem;
+  line-height: 1.72;
+  color: #c8cdd4;
+  text-wrap: pretty;
+}
+#explainer ul { margin: 0 0 0.95rem; padding-left: 1.1rem; }
+#explainer li { margin-bottom: 0.55rem; }
+#explainer li::marker { color: var(--accent); }
+#explainer strong, #explainer b { color: var(--ink); font-weight: 600; }
+#explainer em { font-style: italic; }
+#explainer .abstract {
+  padding-left: 1rem;
+  border-left: 2px solid var(--accent);
+  color: var(--ink);
+}
+
+/* KaTeX inherits the panel's colour, and long display maths scrolls in its own box
+   rather than widening the dialog. */
+#explainer .katex { color: var(--ink); font-size: 1em; }
+#explainer .katex-display {
+  margin: 1.1rem 0;
+  padding: 0.2rem 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+/* ---- the guide sheet ---- */
 
 #sheet {
   position: fixed;

--- a/demos/blast-wall/src/ui/explainer.ts
+++ b/demos/blast-wall/src/ui/explainer.ts
@@ -1,0 +1,67 @@
+import { PAPER } from './paper.ts';
+
+/**
+ * The "Theory" modal.
+ *
+ * KaTeX and its web fonts are a few hundred kilobytes, so both the library and the
+ * typeset paper are built on first open rather than at start-up. Nobody arriving to blow
+ * up a wall should wait on a typesetting engine for a panel they may never open.
+ */
+export function createExplainer(): { open(): Promise<void> } {
+  let dialog: HTMLDialogElement | null = null;
+  let building: Promise<HTMLDialogElement> | null = null;
+
+  async function build(): Promise<HTMLDialogElement> {
+    const [katex] = await Promise.all([
+      import('katex').then((m) => m.default),
+      import('katex/dist/katex.min.css'),
+    ]);
+
+    const el = document.createElement('dialog');
+    el.id = 'explainer';
+
+    const close = document.createElement('button');
+    close.className = 'explainer-close';
+    close.type = 'button';
+    close.setAttribute('aria-label', 'Close');
+    close.textContent = '×';
+    close.addEventListener('click', () => el.close());
+
+    const article = document.createElement('article');
+    // Display maths is substituted before inline, so that its delimiters cannot be
+    // mistaken for two adjacent inline spans.
+    article.innerHTML = PAPER.replace(/\$\$([\s\S]+?)\$\$/g, (_, tex: string) =>
+      katex.renderToString(tex, { displayMode: true, throwOnError: false }),
+    ).replace(/\$([^$\n]+?)\$/g, (_, tex: string) =>
+      katex.renderToString(tex, { displayMode: false, throwOnError: false }),
+    );
+
+    el.append(close, article);
+    // The dialog fills the viewport, so a click landing on it rather than on the article
+    // is a click on the backdrop.
+    el.addEventListener('click', (event) => {
+      if (event.target === el) el.close();
+    });
+    document.body.append(el);
+    return el;
+  }
+
+  return {
+    async open() {
+      building ??= build();
+      try {
+        dialog = await building;
+      } catch {
+        // A failed lazy import (offline, chunk 404) must not be cached forever — clear
+        // it so the next click retries the load.
+        building = null;
+        return;
+      }
+      if (!dialog.open) dialog.showModal();
+      // showModal moves focus to the first focusable child and the browser scrolls it
+      // into view, which lands the reader mid-paper. Reset once that has happened.
+      const article = dialog.querySelector('article');
+      requestAnimationFrame(() => article?.scrollTo(0, 0));
+    },
+  };
+}

--- a/demos/blast-wall/src/ui/paper.ts
+++ b/demos/blast-wall/src/ui/paper.ts
@@ -1,0 +1,294 @@
+/**
+ * The "Theory" text. One HTML template string; $…$ and $$…$$ spans are typeset with
+ * KaTeX by explainer.ts on first open.
+ *
+ * Backslashes are doubled throughout because this is a template literal: a bare \r or
+ * \t in LaTeX would become a carriage return or a tab before KaTeX ever saw it.
+ */
+
+export const PAPER = `
+<h1>A brick wall, from the weak form up</h1>
+<p class="byline">On what this solver actually solves, the choices behind it, and what it leaves out.</p>
+
+<section>
+  <h2>Abstract</h2>
+  <p class="abstract">
+    Every brick on screen is a mesh of hexahedral finite elements, and every mortar joint
+    between them is a surface with a traction that depends on how far its two faces have
+    opened or slid. Nothing about the crack path is drawn — it is wherever joints exceeded
+    their strength. This is the chain from momentum balance to the pixels, and then an
+    equally explicit list of everything the model does not do.
+  </p>
+</section>
+
+<section>
+  <h2>What is being solved</h2>
+  <p>
+    Each brick is a continuum body $\\Omega_b$ obeying momentum balance,
+  </p>
+  $$\\rho\\,\\ddot{\\mathbf{u}} = \\nabla\\cdot\\boldsymbol{\\sigma} + \\rho\\,\\mathbf{b},$$
+  <p>
+    with Cauchy stress $\\boldsymbol{\\sigma}$, density $\\rho$ and body force $\\mathbf{b}$.
+    On exposed faces the blast supplies a traction. None of that is specific to masonry.
+    What makes it masonry is the last condition: between two bricks lies a surface
+    $\\Gamma_j$ across which displacement may be <em>discontinuous</em>, carrying a
+    traction that depends on the jump,
+  </p>
+  $$\\mathbf{T} = \\mathbf{T}(\\Delta\\mathbf{u}), \\qquad \\Delta\\mathbf{u} = \\mathbf{u}^{+} - \\mathbf{u}^{-}.$$
+  <p>
+    A wall is not a continuum with bricks drawn on it. It is a few hundred continua
+    stitched together by tens of thousands of these surfaces, and essentially everything
+    interesting — the crack path, the failure mode, the reason bond patterns exist —
+    lives in $\\mathbf{T}(\\Delta\\mathbf{u})$ rather than in $\\boldsymbol{\\sigma}$.
+  </p>
+</section>
+
+<section>
+  <h2>The weak form</h2>
+  <p>
+    Multiply by an admissible variation $\\delta\\mathbf{u}$, integrate over each brick and
+    integrate the divergence term by parts. The boundary term splits into the exposed
+    surfaces, which carry the applied traction, and the joints, which carry the interface
+    traction:
+  </p>
+  $$\\sum_b \\int_{\\Omega_b} \\rho\\,\\delta\\mathbf{u}\\cdot\\ddot{\\mathbf{u}}\\,d\\Omega
+   + \\sum_b \\int_{\\Omega_b} \\delta\\boldsymbol{\\varepsilon} : \\boldsymbol{\\sigma}\\,d\\Omega
+   + \\sum_j \\int_{\\Gamma_j} \\Delta(\\delta\\mathbf{u})\\cdot\\mathbf{T}\\,d\\Gamma
+   = \\sum_b \\int_{\\Gamma_t} \\delta\\mathbf{u}\\cdot\\bar{\\mathbf{t}}\\,d\\Gamma
+   + \\sum_b \\int_{\\Omega_b} \\rho\\,\\delta\\mathbf{u}\\cdot\\mathbf{b}\\,d\\Omega$$
+  <p>
+    Four integrals — inertia, internal work, interface work, external work. Everything
+    below is a decision about how to evaluate one of them.
+  </p>
+</section>
+
+<section>
+  <h2>Choosing the element</h2>
+  <p>
+    Inside a brick the displacement is interpolated from nodal values with trilinear
+    hexahedral shape functions,
+  </p>
+  $$N_a(\\xi,\\eta,\\zeta) = \\tfrac{1}{8}(1+\\xi_a\\xi)(1+\\eta_a\\eta)(1+\\zeta_a\\zeta),$$
+  <p>
+    where $(\\xi_a,\\eta_a,\\zeta_a)$ are the corner's $\\pm 1$ coordinates, and strains
+    follow as $\\boldsymbol{\\varepsilon} = \\mathbf{B}\\,\\mathbf{u}_e$ with $\\mathbf{B}$
+    the $6\\times 24$ strain–displacement operator. Four reasons for that element and not
+    another:
+  </p>
+  <ul>
+    <li>
+      <strong>The geometry is boxes.</strong> Every unit sits on a lattice and is
+      subdivided uniformly, so hexahedra tile it exactly. There is no meshing step at all.
+    </li>
+    <li>
+      <strong>Linear tetrahedra would be a poor trade.</strong> A four-node tet is
+      constant-strain and badly over-stiff in bending; matching this takes many times more
+      elements, each one shortening the stable time step.
+    </li>
+    <li>
+      <strong>Quadratic elements would be worse here, not better.</strong> More accurate
+      per degree of freedom, but the explicit time step scales with the smallest element
+      dimension and lumping mass onto mid-side nodes is awkward. Explicit codes
+      overwhelmingly use eight-node hexes for exactly this reason.
+    </li>
+    <li>
+      <strong>Full $2\\times2\\times2$ Gauss, not one-point reduced.</strong> Reduced
+      integration is four times cheaper but admits zero-energy hourglass modes needing an
+      artificial stabilising stiffness with a coefficient somebody has to choose. Since
+      every element here is the same box, the stiffness is integrated once for the whole
+      model, so reduced integration would save nothing and cost a fudge factor.
+    </li>
+  </ul>
+</section>
+
+<section>
+  <h2>The integrals</h2>
+  <p>The element stiffness is the internal-work integral with the isotropic matrix $\\mathbf{D}$:</p>
+  $$\\mathbf{K}_e = \\int_{\\Omega_e}\\mathbf{B}^{\\mathsf{T}}\\mathbf{D}\\,\\mathbf{B}\\;d\\Omega
+    = \\sum_{g=1}^{8} w_g\\,\\mathbf{B}^{\\mathsf{T}}(\\boldsymbol{\\xi}_g)\\,\\mathbf{D}\\,\\mathbf{B}(\\boldsymbol{\\xi}_g)\\,\\det\\mathbf{J}$$
+  <p>
+    For an axis-aligned box of sides $a\\times b\\times c$ the Jacobian is constant and
+    diagonal, $\\mathbf{J} = \\mathrm{diag}(a/2, b/2, c/2)$ with
+    $\\det\\mathbf{J} = abc/8$, so the mapping never varies across the element and physical
+    derivatives are simply $\\partial N_a/\\partial x = (2/a)\\,\\partial N_a/\\partial\\xi$.
+    The eight Gauss points at $\\pm 1/\\sqrt{3}$ integrate the integrand exactly — it is at
+    most cubic in each variable, and two-point Gauss is exact to degree three.
+  </p>
+  <p>
+    The consistent mass $\\int_{\\Omega_e}\\rho\\,\\mathbf{N}^{\\mathsf{T}}\\mathbf{N}\\,d\\Omega$
+    is row-summed to a diagonal, which for this element gives exactly
+    $M_{aa} = \\rho V_e/8$. Lumping is not laziness: it turns the update into a division
+    rather than a linear solve, and a lumped mass has a slightly <em>higher</em> critical
+    time step than a consistent one.
+  </p>
+  <p>
+    And then the economy that shapes the whole codebase. Because every unit is on one
+    lattice and subdivided uniformly, <strong>every $\\Omega_e$ in the model is the same
+    box</strong> — so $\\mathbf{K}_e$ is 576 numbers computed once and shared by all 28 000
+    elements. The internal force is one $24\\times24$ matrix–vector product per element,
+    which is what makes it cheap enough for a GPU to do tens of millions of times a second.
+  </p>
+</section>
+
+<section>
+  <h2>Large rotations without large-strain theory</h2>
+  <p>
+    Linear elasticity is valid only for small displacement <em>gradients</em>, and a brick
+    tumbling through the air has small strain with an enormous rotation. Feed that rotation
+    into a linear element and it reads as strain: the brick appears to stretch violently
+    and tears itself apart.
+  </p>
+  <p>
+    So the rotation is extracted and the strain measured in the element's own frame. The
+    deformation gradient at the element centre is
+  </p>
+  $$\\mathbf{F} = \\sum_{a=1}^{8}(\\mathbf{x}_a - \\bar{\\mathbf{x}}) \\otimes \\nabla_X N_a\\big|_{\\boldsymbol{\\xi}=0},
+    \\qquad \\nabla_X N_a\\big|_{0} = \\left(\\frac{\\xi_a}{4a},\\ \\frac{\\eta_a}{4b},\\ \\frac{\\zeta_a}{4c}\\right),$$
+  <p>
+    polar-decomposed as $\\mathbf{F} = \\mathbf{R}\\,\\mathbf{U}$, and the internal force
+    becomes
+  </p>
+  $$\\mathbf{f}^{\\,e}_{\\text{int}} = -\\,\\mathbf{R}\\,\\mathbf{K}_e\\Big(\\mathbf{R}^{\\mathsf{T}}(\\mathbf{x}_e - \\bar{\\mathbf{x}}) - (\\mathbf{X}_e - \\bar{\\mathbf{X}})\\Big),$$
+  <p>
+    which is exactly zero for any rigid motion and reduces to linear elasticity when
+    $\\mathbf{R} = \\mathbf{I}$. $\\mathbf{R}$ comes from Müller's iterative quaternion
+    method rather than an SVD: with $\\mathbf{r}_c$ and $\\mathbf{f}_c$ the columns of the
+    current $\\mathbf{R}$ and of $\\mathbf{F}$, each iteration applies the axis-angle
+    correction
+  </p>
+  $$\\boldsymbol{\\omega} = \\frac{\\sum_c \\mathbf{r}_c \\times \\mathbf{f}_c}{\\left|\\sum_c \\mathbf{r}_c\\cdot\\mathbf{f}_c\\right| + \\epsilon}.$$
+  <p>
+    Warm-started from the previous step it converges in one or two iterations, because a
+    brick barely turns in ten microseconds. That warm start is the entire reason this is
+    affordable inside a per-element GPU kernel. It is a corotational <em>linear</em>
+    material: exact for arbitrary rotation, first-order in strain.
+  </p>
+</section>
+
+<section>
+  <h2>The joints</h2>
+  <p>
+    Zero-thickness interface, with the jump split into normal and tangential parts,
+    $\\Delta_n = \\Delta\\mathbf{u}\\cdot\\mathbf{n}$ and
+    $\\Delta_s = \\Delta\\mathbf{u} - \\Delta_n\\mathbf{n}$. The elastic stiffnesses come
+    from smearing the real mortar layer over its thickness $t_m$,
+  </p>
+  $$k_n = \\frac{E_u E_m}{t_m (E_u - E_m)}, \\qquad k_s = \\frac{G_u G_m}{t_m (G_u - G_m)},$$
+  <p>
+    which for 1 GPa mortar in a 12 mm joint lands near 80 N/mm³ — and the value Lourenço
+    and Rots calibrate against the TU Delft shear walls is 82. Mode I is a bilinear
+    cohesive law driven by $\\kappa$, the largest opening the joint has ever reached:
+  </p>
+  $$\\sigma(\\kappa) = \\begin{cases}
+      k_n\\,\\kappa, & \\kappa \\le \\delta_0 \\\\
+      f_t\\,\\dfrac{\\delta_f - \\kappa}{\\delta_f - \\delta_0}, & \\delta_0 < \\kappa < \\delta_f \\\\
+      0, & \\kappa \\ge \\delta_f
+    \\end{cases}
+    \\qquad \\delta_0 = \\frac{f_t}{k_n}, \\quad \\delta_f = \\frac{2G_f^{\\,I}}{f_t}$$
+  <p>
+    $\\delta_f$ is chosen so the area under the curve is the fracture energy exactly,
+    $\\int_0^{\\delta_f}\\sigma\\,d\\kappa = \\tfrac12 f_t\\delta_f = G_f^{\\,I}$. Damage is
+    expressed as a loss of secant stiffness, $D = 1 - k_{\\text{sec}}/k_n$, which makes
+    unloading run back to the origin instead of retracing the envelope — the difference
+    between a joint that has cracked and one that is merely open at this instant.
+    Sliding is Coulomb, with the cohesion carried away by that same damage,
+  </p>
+  $$|\\boldsymbol{\\tau}| \\;\\le\\; c\\,(1-D) \\;+\\; \\max(0,\\,-\\sigma)\\,\\tan\\varphi,$$
+  <p>
+    evaluated by return mapping. Compression is capped at $\\sigma \\ge -f_c$ with the
+    excess closure stored, so a crushed joint does not spring back. That cap looks like a
+    formality — reflected pressures are 0.1 to 1 MPa and masonry crushes near 10 — and it
+    is not. A wall held top and bottom does not resist by bending, it arches, and an arch
+    concentrates its thrust onto a sliver of joint at each hinge. Built without the cap,
+    such a wall turned out to be literally unbreakable. It just rang.
+  </p>
+  <p>
+    One honest departure from a textbook cohesive element: the interface integral is
+    evaluated <em>nodally</em>, with a tributary area $A_p$ at each node pair,
+    $\\int_{\\Gamma_j}\\Delta\\mathbf{u}\\cdot\\mathbf{T}\\,d\\Gamma \\approx \\sum_p A_p\\,\\Delta\\mathbf{u}_p\\cdot\\mathbf{T}_p$.
+    That is a Lobatto-type rule whose points sit exactly on the nodes. It diagonalises the
+    interface the same way row-summing diagonalises the mass, and it is what lets a joint
+    be nothing but a list of node pairs — no surface search, no projection, no
+    master–slave pairing. The price is a traction that is piecewise constant around each
+    node rather than interpolated.
+  </p>
+</section>
+
+<section>
+  <h2>Time integration</h2>
+  <p>The semi-discrete system is integrated by central differences on half-step velocities:</p>
+  $$\\mathbf{v}^{\\,n+1/2} = \\mathbf{v}^{\\,n-1/2} + \\Delta t\\,\\mathbf{M}^{-1}\\!\\left(\\mathbf{f}^{\\,n}_{\\text{ext}} - \\mathbf{f}^{\\,n}_{\\text{int}}\\right),
+    \\qquad \\mathbf{u}^{\\,n+1} = \\mathbf{u}^{\\,n} + \\Delta t\\,\\mathbf{v}^{\\,n+1/2}$$
+  <p>
+    Because $\\mathbf{M}$ is diagonal there is no solve anywhere in the loop — and, more
+    importantly here, the scheme keeps running when elements lose all their stiffness. That
+    is why blast and crash codes are explicit: an implicit solver needs a tangent stiffness
+    that stays invertible, and a wall coming apart does not oblige. The scheme is
+    conditionally stable at $\\Delta t \\le 2/\\omega_{\\max}$, and $\\omega_{\\max}$ is
+    measured rather than guessed — power iteration on $\\mathbf{M}^{-1}\\mathbf{K}_e$ for
+    the element, then compared against the joint springs at
+    $\\omega = \\sqrt{k\\,(1/m_1 + 1/m_2)}$ and the ground penalty, smallest wins, with a
+    safety factor of 0.7. The familiar Courant reading,
+    $\\Delta t \\lesssim L_e/c_d$ with $c_d = \\sqrt{(\\lambda + 2\\mu)/\\rho}$, is the same
+    statement, but only approximate for a hexahedron — and which mechanism governs changes
+    the moment you drag a stiffness slider.
+  </p>
+</section>
+
+<section>
+  <h2>The load</h2>
+  <p>
+    The pressure is prescribed rather than solved for. Peak overpressure and positive-phase
+    duration come from the Kinney and Graham fits in scaled distance
+    $Z = R/W^{1/3}$, the reflected peak from Rankine–Hugoniot, and the history from the
+    modified Friedlander form
+  </p>
+  $$p(t) = P_r\\left(1 - \\frac{t - t_a}{t_d}\\right)e^{-b\\,(t-t_a)/t_d}.$$
+  <p>
+    A CONWEP blend gives each face its own pressure by incidence angle, so a face pointing
+    away feels nothing; arrival times integrate $dR/U(R)$, so the front leaves at several
+    times the speed of sound and decays toward it; and the drawn shock sphere reads the
+    same table, so the picture and the load cannot disagree. Faces that cannot see the
+    charge are found by a line-of-sight march over the lattice and are not loaded at all.
+  </p>
+</section>
+
+<section>
+  <h2>What this is not</h2>
+  <ul>
+    <li><strong>Explicit only.</strong> No tangent stiffness assembly, no Newton iteration, no equation solving. None of this would work for a static problem.</li>
+    <li><strong>Corotational linear, not large-strain.</strong> No hyperelastic material, no objective stress rate.</li>
+    <li><strong>The interface is integrated nodally</strong>, not by Gauss quadrature with interface shape functions.</li>
+    <li><strong>Full integration locks in bending.</strong> With one or two elements through the thickness a brick is far too stiff in flexure. It matters less than it sounds, because a masonry wall's compliance comes from joints opening rather than bricks bending — but it is a real limitation.</li>
+    <li><strong>One damage variable</strong> couples mode I and mode II, so $G_f^{\\,II}$ is not independently controllable.</li>
+    <li><strong>No fragment-to-fragment contact.</strong> A joint can close back up; two pieces that fly into each other pass through.</li>
+    <li><strong>The blast is prescribed.</strong> No fluid domain, no clearing, no diffraction into shadow.</li>
+    <li><strong>Bricks cannot break.</strong> All damage is in the joints. Real bricks do crack, especially close in.</li>
+  </ul>
+</section>
+
+<section>
+  <h2>Verification, not plausibility</h2>
+  <p>
+    Every claim above is worth what the checking behind it is worth, so the demo ships a
+    self-test suite that runs in plain Node with no browser and no GPU. The element's six
+    rigid-body modes produce no force at all, and a uniaxial stretch and a simple shear
+    return $(\\lambda + 2\\mu)\\varepsilon$ and $\\mu\\gamma$ to five decimals. Pulling a
+    joint apart peaks at exactly $f_t$ and dissipates exactly $G_f$. A simulated
+    <em>triplet shear test</em> at four confining pressures recovers the cohesion and
+    $\\tan\\varphi$ it was given from the fitted failure envelope — the actual laboratory
+    test, run inside the solver. Linear momentum is conserved to a part in a million over
+    two thousand steps, which is the check that catches an internal force that is not equal
+    and opposite. And the measured critical time step really is critical: 0.9× is stable
+    and 1.25× diverges.
+  </p>
+  <p>
+    The two claims the demo exists to make get tests rather than screenshots: that the same
+    charge cracks a stack-bonded wall's head joints preferentially — 28 % of them against
+    15 % — because a cracked stussfuge with another directly above it has somewhere to run;
+    and that four walls bonded at the corners hold the ends of a façade that a lone wall
+    cannot, 29 mm of end movement against 117 mm. A simulation that has not been asked to
+    predict something it could have got wrong has not been tested, only run.
+  </p>
+</section>
+`;

--- a/demos/blast-wall/src/ui/sheet.ts
+++ b/demos/blast-wall/src/ui/sheet.ts
@@ -1,18 +1,13 @@
 /**
- * The two documents that live inside the app: a first-run guide, and the theory.
+ * The first-run guide: what you are looking at and what the controls do.
  *
- * The full derivation, properly typeset, is a post on the site. This is the version you
- * can read without leaving the thing it describes — which is the whole point, since a
- * demo whose explanation is somewhere else has no explanation.
- *
- * The equations are HTML and Unicode rather than a maths renderer. There are eight of
- * them; a typesetting dependency to set eight formulas would cost more than it returns,
- * and the site has the typeset version one link away.
+ * The theory is a separate, typeset document — see `explainer.ts`, which lazily loads
+ * KaTeX so the maths is set properly rather than approximated in Unicode.
  */
 
 const SEEN_KEY = 'blast-wall.guide.seen';
 
-export type SheetName = 'guide' | 'theory';
+export type SheetName = 'guide';
 
 const GUIDE = /* html */ `
 <p class="lede">
@@ -60,116 +55,9 @@ const GUIDE = /* html */ `
 </p>
 `;
 
-const THEORY = /* html */ `
-<p class="lede">
-  This is a finite element model, not a spring toy. Here is the chain, and then an honest
-  list of what it leaves out.
-</p>
+const TITLES: Record<SheetName, string> = { guide: 'What you are looking at' };
 
-<h3>What is being solved</h3>
-<p>
-  Each brick is a continuum obeying momentum balance, <span class="eq">ρ ü = ∇·σ + ρb</span>.
-  What makes it masonry is the other condition: between two bricks sits a surface across
-  which displacement may be <i>discontinuous</i>, carrying a traction that depends on how
-  far the faces have opened or slid, <span class="eq">T = T(Δu)</span>. A wall is a few
-  hundred continua stitched together by tens of thousands of those surfaces, and nearly
-  everything interesting lives in the stitching.
-</p>
-
-<h3>The element</h3>
-<p>
-  Trilinear hexahedra — eight nodes, <span class="eq">N<sub>a</sub> = ⅛(1+ξ<sub>a</sub>ξ)(1+η<sub>a</sub>η)(1+ζ<sub>a</sub>ζ)</span>.
-  The geometry is boxes on a lattice, so hexahedra tile it exactly and there is no meshing
-  step. Linear tetrahedra would be constant-strain and far too stiff; quadratic elements
-  would shorten the explicit time step and complicate mass lumping. Full 2×2×2 Gauss
-  rather than one-point reduced, so there are no hourglass modes needing an artificial
-  stabilising stiffness.
-</p>
-
-<h3>The integrals</h3>
-<p class="eq block">K<sub>e</sub> = ∫ B<sup>T</sup> D B dΩ = Σ<sub>g</sub> w<sub>g</sub> B<sup>T</sup>(ξ<sub>g</sub>) D B(ξ<sub>g</sub>) det J</p>
-<p>
-  For an axis-aligned box the Jacobian is constant, <span class="eq">det J = abc/8</span>,
-  and two-point Gauss integrates the trilinear integrand exactly. Because every unit sits
-  on one lattice and is subdivided uniformly, <b>every element in the model is the same
-  box</b> — so this 24×24 matrix is built once and shared by all 28 000 of them. The mass
-  matrix is row-summed to a diagonal, <span class="eq">M<sub>aa</sub> = ρV/8</span>, which
-  turns the time step into a division instead of a linear solve.
-</p>
-
-<h3>Large rotations</h3>
-<p>
-  A tumbling brick has small strain and an enormous rotation, and linear elasticity reads
-  that rotation as strain. So the rotation is extracted from the deformation gradient by
-  iterative polar decomposition — warm-started from the previous step, so it converges in
-  one or two iterations — and the strain measured in the element's own frame:
-</p>
-<p class="eq block">f<sub>int</sub> = −R K<sub>e</sub> ( R<sup>T</sup>x − X )</p>
-
-<h3>The joints</h3>
-<p>
-  Elastic stiffness comes from smearing the real mortar over its thickness,
-  <span class="eq">k<sub>n</sub> = E<sub>u</sub>E<sub>m</sub> / t<sub>m</sub>(E<sub>u</sub>−E<sub>m</sub>)</span>
-  ≈ 80 N/mm³, which is what the experiments calibrate to. Then a bilinear cohesive law in
-  tension, rising to f<sub>t</sub> and falling linearly to zero at
-</p>
-<p class="eq block">δ<sub>f</sub> = 2G<sub>f</sub>/f<sub>t</sub>&nbsp;&nbsp;&nbsp;so that&nbsp;&nbsp;&nbsp;∫ σ dδ = ½ f<sub>t</sub> δ<sub>f</sub> = G<sub>f</sub></p>
-<p>
-  — the area under the curve <i>is</i> the fracture energy, by construction. Damage is a
-  loss of secant stiffness, so unloading returns to the origin. Sliding is Coulomb,
-  <span class="eq">|τ| ≤ c(1−D) + max(0,−σ)·tanφ</span>, and compression is capped at
-  f<sub>c</sub> with a permanent set. That cap is not decorative: a wall held top and
-  bottom resists by arching, and an arch concentrates its thrust onto a sliver of joint,
-  so without the cap such a wall is unbreakable.
-</p>
-
-<h3>Time integration</h3>
-<p class="eq block">v<sup>n+½</sup> = v<sup>n−½</sup> + Δt M<sup>−1</sup>( f<sub>ext</sub> − f<sub>int</sub> )&nbsp;&nbsp;&nbsp;u<sup>n+1</sup> = u<sup>n</sup> + Δt v<sup>n+½</sup></p>
-<p>
-  Central difference on a diagonal mass — no solve, and it keeps running after elements
-  lose all their stiffness, which is exactly what a wall coming apart does to them. It is
-  conditionally stable at <span class="eq">Δt ≤ 2/ω<sub>max</sub></span>, and ω<sub>max</sub>
-  is <i>measured</i> by power iteration on the element, then compared against the joint
-  springs and the ground contact; the smallest wins. Which of the three governs changes the
-  moment you drag a stiffness slider.
-</p>
-
-<h3>The load</h3>
-<p>
-  A modified Friedlander pulse,
-  <span class="eq">p = P<sub>r</sub>(1 − τ)e<sup>−bτ</sup></span>, with peak and duration
-  from the Kinney &amp; Graham fits in scaled distance Z = R/W<sup>⅓</sup>, the reflected
-  peak from Rankine–Hugoniot, and a CONWEP blend giving each face its own pressure by
-  incidence angle. Arrival times integrate dR/U(R), so the front decelerates — and the
-  drawn shock sphere reads the same table, so the picture and the load cannot disagree.
-  Faces that cannot see the charge are found by a line-of-sight march over the lattice and
-  are not loaded.
-</p>
-
-<h3>What this is not</h3>
-<ul class="caveats">
-  <li><b>Explicit only.</b> No tangent stiffness, no Newton iteration, no equation solving. None of this would work for a static problem.</li>
-  <li><b>Corotational linear, not large-strain.</b> Valid for small strain with arbitrary rotation.</li>
-  <li><b>The interface is integrated nodally</b>, not by quadrature with interface shape functions.</li>
-  <li><b>H8 locks in bending.</b> It matters less here because a wall's compliance is in its joints, but it is a real limitation.</li>
-  <li><b>One damage variable</b> couples mode I and mode II, so mode II fracture energy is not independently controllable.</li>
-  <li><b>No fragment-to-fragment contact.</b> A joint can close back up; two pieces that fly into each other pass through.</li>
-  <li><b>The blast is prescribed</b>, not solved. No fluid, no clearing, no diffraction into shadow.</li>
-  <li><b>Bricks cannot break.</b> All damage is in the joints.</li>
-</ul>
-
-<p class="foot">
-  The full derivation, properly typeset — weak form, quadrature, stability — is at
-  <a href="/blog/a-brick-wall-from-the-weak-form-up">A brick wall, from the weak form up</a>.
-</p>
-`;
-
-const TITLES: Record<SheetName, string> = {
-  guide: 'What you are looking at',
-  theory: 'The theory',
-};
-
-const BODIES: Record<SheetName, string> = { guide: GUIDE, theory: THEORY };
+const BODIES: Record<SheetName, string> = { guide: GUIDE };
 
 export class Sheet {
   private readonly root: HTMLElement;


### PR DESCRIPTION
Follow-up to #29.

The theory panel was setting eight equations in HTML and Unicode, with a comment of mine arguing that a typesetting dependency would cost more than it returned. That was a divergence from the pattern already in this repo — `ising` has a `paper.ts` of LaTeX and an `explainer.ts` that lazily imports KaTeX to typeset it — and the reasoning was thin: it saved a dependency the site already ships, at the price of piecewise functions rendered as prose and integrals that had to be described rather than written.

This follows the house pattern exactly.

- `src/ui/paper.ts` — the theory as one HTML template with `$…$` and `$$…$$` spans.
- `src/ui/explainer.ts` — builds a `<dialog>` on first open, importing KaTeX and its stylesheet at that moment rather than at start-up.

Vite splits KaTeX into its own 261 kB chunk; the main bundle is unchanged at 88 kB, so nobody arriving to blow up a wall waits on a typesetting engine for a panel they may never open.

**What it buys, concretely:** the bilinear cohesive law is an actual piecewise function with a brace instead of three sentences; the weak form is one displayed equation instead of a paragraph describing four integrals; the stiffness integral, the polar decomposition and the central-difference update read as mathematics.

**Verified in Chrome:** 13 display equations, 70 inline, **zero KaTeX parse errors**, and the dialog reopens without rebuilding.

The guide sheet keeps its own simpler markup — it is prose and has no equations in it — and now says the theory is typeset next door.

One note for whoever edits `paper.ts` next: it is a template literal, so every LaTeX backslash is doubled. A bare `\rho` would become a carriage return before KaTeX ever saw it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
