### PR TITLE
Add Music and 3D rendering interests

### DIFF
--- a/src/features/rendering/AtomsIllustration.tsx
+++ b/src/features/rendering/AtomsIllustration.tsx
@@ -1,0 +1,40 @@
+import { useId } from 'react'
+
+// A schematic of atom positions and their screen-facing bounds, not a molecular model.
+const atoms = [
+  { x: 160, y: 62, r: 22 },
+  { x: 370, y: 50, r: 24 },
+  { x: 274, y: 100, r: 36 },
+  { x: 426, y: 153, r: 32 },
+  { x: 185, y: 180, r: 30 },
+]
+const bonds = [[0, 2], [1, 2], [2, 3], [2, 4]]
+
+export default function AtomsIllustration({ bounds = false }: { bounds?: boolean }) {
+  const id = useId()
+  return (
+    <svg viewBox="0 0 600 240" aria-hidden="true" className="block w-full">
+      <defs>
+        <radialGradient id={id} cx="32%" cy="26%" r="75%">
+          <stop offset="0" stopColor="#e2f5ff" />
+          <stop offset="0.25" stopColor="#91b5f8" />
+          <stop offset="0.7" stopColor="#4c6ea7" />
+          <stop offset="1" stopColor="#17243e" />
+        </radialGradient>
+      </defs>
+      {bonds.map(([a, b]) => (
+        <g key={`${a}-${b}`} strokeLinecap="round">
+          <line x1={atoms[a].x} y1={atoms[a].y} x2={atoms[b].x} y2={atoms[b].y} stroke="#334761" strokeWidth="15" />
+          <line x1={atoms[a].x} y1={atoms[a].y - 2} x2={atoms[b].x} y2={atoms[b].y - 2} stroke="#8babc5" strokeWidth="6" />
+        </g>
+      ))}
+      {atoms.map(({ x, y, r }, i) => <circle key={i} cx={x} cy={y} r={r} fill={`url(#${id})`} />)}
+      {bounds && atoms.map(({ x, y, r }, i) => (
+        <g key={i} stroke="#e9bf7d" strokeWidth="1" fill="none">
+          <rect x={x - r} y={y - r} width={2 * r} height={2 * r} strokeDasharray="4 3" />
+          <path d={`M${x - r} ${y - r} L${x + r} ${y + r}`} opacity="0.6" />
+        </g>
+      ))}
+    </svg>
+  )
+}

--- a/src/pages/Interests.tsx
+++ b/src/pages/Interests.tsx
@@ -1,11 +1,12 @@
 import { Link } from "react-router-dom";
+import AtomsIllustration from "@/features/rendering/AtomsIllustration";
 import "@/features/neural-operators/research.css";
 export default function Interests() {
   return (
     <div className="no-root">
-      <p className="no-eyebrow">Reading, questions & connections</p>
+      <p className="no-eyebrow">Learning, playing & exploring</p>
       <h1 className="no-page-title">Interests</h1>
-      <p className="no-lead">Topics I’m exploring, with the papers and ideas behind them.</p>
+      <p className="no-lead">Things I enjoy exploring, with the ideas, experiments and projects behind them.</p>
       <Link className="no-interest-card" to="/interests/neural-operators">
         <div className="no-card-art" aria-hidden="true">
           <svg viewBox="0 0 600 180">
@@ -35,6 +36,51 @@ export default function Interests() {
             <span>Literature graph</span>
             <span>Concepts</span>
             <span>Timeline</span>
+          </div>
+        </div>
+      </Link>
+      <Link className="no-interest-card" to="/interests/music">
+        <div className="no-card-art" aria-hidden="true">
+          <svg viewBox="0 0 600 180">
+            {Array.from({ length: 14 }, (_, i) => (
+              <rect key={i} x={91 + i * 30} y="35" width="28" height="110" rx="3" fill="currentColor" opacity="0.75" />
+            ))}
+            {[0, 1, 3, 4, 5, 7, 8, 10, 11, 12].map((i) => (
+              <rect key={i} x={111 + i * 30} y="35" width="18" height="68" rx="2" fill="#111723" />
+            ))}
+          </svg>
+          <span>PIANO · GUITAR · SOUND</span>
+        </div>
+        <div className="no-card-body">
+          <p className="no-eyebrow">Playing & understanding</p>
+          <h2>Music <span>↗</span></h2>
+          <p>
+            Piano since childhood, a guitar ambition, and curiosity about music theory
+            and the physics of sound.
+          </p>
+          <div className="no-tags">
+            <span>Music theory</span>
+            <span>Ear training</span>
+            <span>Acoustics</span>
+          </div>
+        </div>
+      </Link>
+      <Link className="no-interest-card" to="/interests/3d-rendering">
+        <div className="no-card-art" aria-hidden="true">
+          <AtomsIllustration />
+          <span>ATOMS · BONDS · PERCEPTION</span>
+        </div>
+        <div className="no-card-body">
+          <p className="no-eyebrow">The unreasonable effectiveness of</p>
+          <h2>3D rendering <span>↗</span></h2>
+          <p>
+            Why a few well-lit spheres make people stop and look. Billboards, atoms and
+            bonds, and giving the visual brain something to work with.
+          </p>
+          <div className="no-tags">
+            <span>Billboarding</span>
+            <span>Molecular graphics</span>
+            <span>Visual perception</span>
           </div>
         </div>
       </Link>

--- a/src/pages/Music.tsx
+++ b/src/pages/Music.tsx
@@ -1,0 +1,99 @@
+import { Link } from 'react-router-dom'
+import intervalTrainer from '@/content/projects/interval-trainer'
+import tubeSim from '@/content/projects/tube-sim'
+import '@/features/neural-operators/research.css'
+
+const experiments = [
+  {
+    project: intervalTrainer,
+    eyebrow: 'Train your ear',
+    description: 'Hear a root and fifth together, then try to recognise the note that follows. Practise at your own pace or play against the clock, with the sounds drawn as waves behind the notes.',
+    action: 'Practise intervals',
+    post: 'a-perfect-fifth-you-can-see',
+    postTitle: 'A perfect fifth you can see',
+  },
+  {
+    project: tubeSim,
+    eyebrow: 'Explore the physics',
+    description: 'Strike a tube and watch a pressure wave travel, reflect and escape through a hole. Change the hole or cap the end to explore the acoustics behind a flute-like tube in a 2D simulation.',
+    action: 'Open the acoustics lab',
+    post: 'a-hole-in-a-tube-is-not-a-leak-coefficient',
+    postTitle: 'A hole in a tube is not a leak coefficient',
+  },
+]
+
+export default function Music() {
+  return (
+    <div className="no-root">
+      <nav className="no-breadcrumb" aria-label="Breadcrumb">
+        <Link to="/interests">Interests</Link>
+        <span aria-hidden="true">/</span>
+        <span aria-current="page">Music</span>
+      </nav>
+
+      <header className="mb-10">
+        <p className="no-eyebrow">Piano, guitar & the physics of sound</p>
+        <h1 className="no-page-title">Music</h1>
+        <p className="no-lead">
+          Playing for the enjoyment of it, and trying to understand a little more of what I hear.
+        </p>
+      </header>
+
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
+        <section className="no-article" aria-labelledby="music-playing">
+          <h2 id="music-playing">Mostly, I just enjoy playing</h2>
+          <p>
+            I’ve played the piano since I was about seven or eight. I’m an okay player,
+            I suppose, but what has kept me at it is how much I enjoy it.
+          </p>
+          <p>
+            I also play some guitar, and I’d like to buy an electric guitar soon.
+            One goal, sometime in my life, is to play <em>Shine On You Crazy Diamond</em> beautifully.
+            That feels like something worth working towards.
+          </p>
+        </section>
+
+        <section className="no-article" aria-labelledby="music-theory">
+          <h2 id="music-theory">The theory is part of the fun</h2>
+          <p>
+            I’m also interested in music theory and the things around music: recognising
+            intervals, understanding how notes fit together, and connecting what I hear
+            with what I’m playing.
+          </p>
+          <p>
+            Then there’s the physics. Notes are vibrations, instruments shape sound,
+            and a hole in a tube becomes a surprisingly interesting simulation problem.
+            The apps below are two ways of exploring that curiosity.
+          </p>
+        </section>
+      </div>
+
+      <section className="mt-12" aria-labelledby="music-experiments">
+        <p className="no-eyebrow">Listen, practise, experiment</p>
+        <h2 id="music-experiments" className="text-2xl font-semibold tracking-tight mb-6">Music you can explore</h2>
+        <div className="grid gap-6 md:grid-cols-2">
+          {experiments.map(({ project, eyebrow, description, action, post, postTitle }) => (
+            <article key={project.slug} className="overflow-hidden rounded-xl border border-[#292c36] bg-[#12151c] flex flex-col">
+              <a href={project.liveUrl} aria-label={action} className="block">
+                <img src={project.screenshot} alt={`${project.title} preview`} loading="lazy" className="aspect-video w-full object-cover" />
+              </a>
+              <div className="p-6 flex flex-col flex-1">
+                <p className="no-eyebrow">{eyebrow}</p>
+                <h3 className="text-xl font-semibold mb-3">{project.title}</h3>
+                <p className="text-[#a1a4b0] leading-relaxed mb-6">{description}</p>
+                <div className="mt-auto">
+                  <a href={project.liveUrl} className="inline-block rounded-lg border border-[#53618b] bg-[#1b2331] px-4 py-2 text-sm text-[#c6d2ff] hover:bg-[#29324c]">
+                    {action} <span aria-hidden="true">↗</span>
+                  </a>
+                  <p className="mt-4 text-sm leading-relaxed text-[#a1a4b0]">
+                    Behind the app: <Link className="text-[#9eafff] hover:underline" to={`/blog/${post}`}>{postTitle}</Link>
+                  </p>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/pages/Rendering.tsx
+++ b/src/pages/Rendering.tsx
@@ -1,0 +1,156 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import AtomsIllustration from '@/features/rendering/AtomsIllustration'
+import atomify from '@/content/projects/atomify'
+import raytracing from '@/content/projects/raytracing'
+import webgpuMd from '@/content/projects/webgpu-md'
+import '@/features/neural-operators/research.css'
+
+const projects = [
+  { project: atomify, text: 'Run molecular dynamics and watch the atoms move. This is where my interest in making simulations visible really took shape.', action: 'Open Atomify' },
+  { project: raytracing, text: 'Explore the ray–sphere and ray–cylinder intersections behind atom and bond rendering, then work up to the torus.', action: 'Explore the intersections' },
+  { project: webgpuMd, text: 'GPU simulation and rendering meet in a browser tab: explore how a collection of individual particles becomes a material in motion.', action: 'Open WebGPU MD' },
+]
+
+export default function Rendering() {
+  const [bounds, setBounds] = useState(false)
+
+  return (
+    <div className="no-root">
+      <nav className="no-breadcrumb" aria-label="Breadcrumb">
+        <Link to="/interests">Interests</Link>
+        <span aria-hidden="true">/</span>
+        <span aria-current="page">3D rendering</span>
+      </nav>
+
+      <header className="mb-10 max-w-4xl">
+        <p className="no-eyebrow">Atoms, bonds & the visual brain</p>
+        <h1 className="no-page-title">The unreasonable effectiveness of 3D rendering</h1>
+        <p className="no-lead">
+          A few spheres, some light, and suddenly people want to know what they’re looking at.
+          I find that both useful and fascinating.
+        </p>
+      </header>
+
+      <div className="grid gap-8 lg:grid-cols-2 mb-8">
+        <section className="no-article" aria-labelledby="rendering-attention">
+          <h2 id="rendering-attention">First, it makes you look</h2>
+          <p>
+            I like how much a good 3D rendering can change someone’s reaction to a simulation.
+            Give the atoms some shape, light them nicely, let people turn the scene around,
+            and something quite technical becomes something they want to play with.
+            People get impressed. They enjoy looking at it. I think that matters.
+          </p>
+          <p>
+            That first bit of attention is an invitation. A person who stops to look can
+            start asking questions: what is moving, why does that region look different,
+            what happens if I change the temperature? The picture gives the conversation
+            somewhere to begin.
+          </p>
+        </section>
+
+        <figure className="rounded-xl border border-[#303546] bg-[#111723] overflow-hidden flex flex-col justify-center">
+          <AtomsIllustration bounds={bounds} />
+          <figcaption className="px-6 pb-6 text-sm leading-relaxed text-[#a1a4b0]">
+            <label className="flex items-center gap-3 text-[#e7e8ed] mb-4 cursor-pointer">
+              <input type="checkbox" checked={bounds} onChange={(event) => setBounds(event.target.checked)} className="accent-[#9eafff] h-4 w-4" />
+              Show the billboard geometry
+            </label>
+            A schematic atom cluster. Turn on the outlines: each apparent sphere fits inside
+            a flat square made of two triangles. In a GPU renderer, the shader supplies the
+            curved surface and its depth. Here, SVG shading illustrates the idea.
+          </figcaption>
+        </figure>
+      </div>
+
+      <div className="grid gap-8 lg:grid-cols-2">
+        <section className="no-article" aria-labelledby="rendering-perception">
+          <h2 id="rendering-perception">Give the visual brain something to work with</h2>
+          <p>
+            A table of coordinates asks you to reconstruct a scene in your head. A rendering
+            does some of that work for you. Overlap suggests what is in front, shading suggests
+            curvature, and rotating the scene helps reveal its shape.
+          </p>
+          <p>
+            There is a lovely example in perception research: people can recover 3D structure
+            from moving dots on a flat screen. <a href="https://pubmed.ncbi.nlm.nih.gov/1771786/">Experiments on structure from motion</a> explore
+            that ability. A screen does not need to be physically three-dimensional to give
+            us a sense of depth.
+          </p>
+          <p>
+            That is part of what I think makes interactive scientific graphics so effective.
+            We get to use our visual intuition to explore an unfamiliar system. With atoms,
+            a crystal, a void, or a moving interface can become a shape to investigate.
+          </p>
+        </section>
+
+        <section className="no-article" aria-labelledby="rendering-bonds">
+          <h2 id="rendering-bonds">Atoms and bonds: a small visual vocabulary</h2>
+          <p>
+            Spheres give positions a visible size and surface. Bonds add connections.
+            Colour can distinguish atom types or show a quantity such as local energy.
+            A surprisingly small set of visual choices can describe a complicated structure.
+          </p>
+          <p>
+            Those choices carry meaning. A drawn bond might represent a chemical bond,
+            or simply a pair selected by a distance rule. Sphere radii and colours are
+            choices too. I’m interested in making that visual vocabulary both appealing
+            and easy to read.
+          </p>
+          <p>
+            Rotation, a cutaway, or hiding one type of atom can be as useful as better
+            lighting. The aim is to help someone notice a relationship, then give them
+            a way to look more closely.
+          </p>
+        </section>
+      </div>
+
+      <section className="no-article mt-8" aria-labelledby="rendering-billboards">
+        <h2 id="rendering-billboards">The sphere is two triangles</h2>
+        <p>
+          One of my favourite tricks is billboarding. For each atom, draw a small quad that
+          faces the camera. It covers the part of the screen where the sphere will appear.
+          For each pixel in that quad, a fragment shader asks whether the viewing ray hits
+          the sphere. Misses are discarded; hits give a surface position and a normal for lighting.
+        </p>
+        <p>
+          The crucial detail is depth: write the depth of the sphere’s surface, rather than
+          the flat quad, so objects overlap correctly. Bonds can use the same idea with
+          ray–cylinder intersections. The geometry stays simple while the pixels describe
+          a smooth curved object.
+        </p>
+        <p>
+          This shifts work from a detailed triangle mesh into the fragment shader. It is
+          particularly appealing when drawing many small atoms, though large, overlapping
+          billboards can still mean a lot of pixel work. <a href="https://developer.nvidia.com/gpugems/gpugems3/part-iv-image-effects/chapter-21-true-impostors">GPU Gems’ chapter on true impostors</a> explores
+          the broader idea of rendering 3D objects through camera-facing quads.
+        </p>
+        <p>
+          I wrote up the analytic intersections in <Link to="/blog/raytracing-from-sphere-to-quartic-torus">Ray tracing by hand</Link>.
+          The connection back to my own simulations is in <Link to="/blog/atomify-molecular-dynamics-for-the-rest-of-us">the story of Atomify</Link>.
+          I love that such a small piece of geometry and mathematics can make a whole
+          simulated world feel tangible.
+        </p>
+      </section>
+
+      <section className="mt-12" aria-labelledby="rendering-projects">
+        <p className="no-eyebrow">From the trick to the simulation</p>
+        <h2 id="rendering-projects" className="text-2xl font-semibold tracking-tight mb-6">See it in practice</h2>
+        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          {projects.map(({ project, text, action }) => (
+            <article key={project.slug} className="rounded-xl border border-[#292c36] bg-[#12151c] overflow-hidden flex flex-col">
+              <Link to={`/projects/${project.slug}`} aria-label={`About ${project.title}`}>
+                <img src={project.screenshot} alt={`${project.title} preview`} loading="lazy" className="aspect-video w-full object-cover" />
+              </Link>
+              <div className="p-6 flex flex-col flex-1">
+                <h3 className="text-xl font-semibold mb-3">{project.title}</h3>
+                <p className="text-[#a1a4b0] leading-relaxed mb-6">{text}</p>
+                <a href={project.liveUrl} className="text-sm text-[#9eafff] hover:underline mt-auto">{action} <span aria-hidden="true">↗</span></a>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -9,6 +9,8 @@ import BlogPost from '@/pages/BlogPost'
 import About from '@/pages/About'
 
 const Interests = lazy(() => import('@/pages/Interests'))
+const Music = lazy(() => import('@/pages/Music'))
+const Rendering = lazy(() => import('@/pages/Rendering'))
 const NeuralOperators = lazy(() => import('@/features/neural-operators/NeuralOperators'))
 
 export const router = createHashRouter([
@@ -19,6 +21,8 @@ export const router = createHashRouter([
       { index: true, element: <Home /> },
       { path: 'projects', element: <Projects /> },
       { path: 'interests', element: <Suspense fallback={<p>Loading interests…</p>}><Interests /></Suspense> },
+      { path: 'interests/music', element: <Suspense fallback={<p>Loading music…</p>}><Music /></Suspense> },
+      { path: 'interests/3d-rendering', element: <Suspense fallback={<p>Loading 3D rendering…</p>}><Rendering /></Suspense> },
       { path: 'interests/neural-operators/:tab?', element: <Suspense fallback={<p>Loading research…</p>}><NeuralOperators /></Suspense> },
       { path: 'projects/:slug', element: <ProjectDetail /> },
       { path: 'blog', element: <Blog /> },


### PR DESCRIPTION
Adds Music and 3D rendering to Interests, with dedicated pages accessible from the interests overview.

The Music page covers piano and guitar, music theory, and links to Interval Trainer and Tube Acoustics Lab. The 3D rendering page connects atoms, bonds and billboarding with visual perception, includes a billboard illustration toggle, and links to Atomify, WebGPU MD and the ray-intersection explorer.

Validation: TypeScript and production build passed locally. Browser review verified interest navigation, both music app destinations, and mouse/keyboard control of the billboard overlay. The full site/demo build and 24 neural-operator tests passed during the music addition; CI checks the combined change.
