### PR TITLE
Teach intervals before notation and correct the consonance explanation

### DIFF
--- a/demos/interval-trainer/src/ui/field.ts
+++ b/demos/interval-trainer/src/ui/field.ts
@@ -7,10 +7,10 @@
  *
  *     lambda = LAMBDA0 * f_root / f_note      and      f_vis = SPEED / lambda
  *
- * and the ratios are the real ones: a fifth's crests are spaced 2/3 of the root's, an
- * octave's half. That is the whole trick — because the ratios are exact, a 3:2 sums into
- * stationary interference fringes while 45:32 (the tritone) never repeats and shimmers.
- * Consonance becomes something you can see.
+ * The frequency ratios follow the equal-tempered notes: a fifth is close to 3:2,
+ * and an octave is 2:1. This slowed field illustrates wavelength and superposition;
+ * unequal-frequency sources do not form stationary fringes, and the image is not
+ * a measure of perceived consonance or a reconstruction of the piano's partials.
  *
  * Displacement of one source, at radius r and time t after its onset:
  *

--- a/demos/interval-trainer/src/ui/tutorial.ts
+++ b/demos/interval-trainer/src/ui/tutorial.ts
@@ -140,10 +140,10 @@ export class Tutorial {
       eyebrow('step 2 of 4'),
       title('Ten places a note can land'),
       para(
-        'Count the major scale from the root: C, D, E, F, G are <b>1, 2, 3, 4, 5</b>.
+        `Count the major scale from the root: C, D, E, F, G are <b>1, 2, 3, 4, 5</b>.
 A degree is not a semitone count: C to E is degree 3 but spans four piano-key steps.
 A <b>semitone</b> is one adjacent key, including black keys; twelve make an octave.
-With C as root, <b>3</b> is E and <b>3b</b> is E-flat. <b>b</b> after a degree means ' +
+With C as root, <b>3</b> is E and <b>3b</b> is E-flat. <b>b</b> after a degree means ` +
           'a semitone lower: <b>3</b> is the bright major third, <b>3b</b> the darker ' +
           'minor one. <b>4#</b> is the restless one halfway up (some write it <b>5b</b>). ' +
           'The root and fifth are not here — the opening chord gives you those for free.',

--- a/demos/interval-trainer/src/ui/tutorial.ts
+++ b/demos/interval-trainer/src/ui/tutorial.ts
@@ -140,7 +140,10 @@ export class Tutorial {
       eyebrow('step 2 of 4'),
       title('Ten places a note can land'),
       para(
-        'The number is how far above the root the note sits, and <b>b</b> after it means ' +
+        'Count the major scale from the root: C, D, E, F, G are <b>1, 2, 3, 4, 5</b>.
+A degree is not a semitone count: C to E is degree 3 but spans four piano-key steps.
+A <b>semitone</b> is one adjacent key, including black keys; twelve make an octave.
+With C as root, <b>3</b> is E and <b>3b</b> is E-flat. <b>b</b> after a degree means ' +
           'a semitone lower: <b>3</b> is the bright major third, <b>3b</b> the darker ' +
           'minor one. <b>4#</b> is the restless one halfway up (some write it <b>5b</b>). ' +
           'The root and fifth are not here — the opening chord gives you those for free.',

--- a/src/content/blog/a-perfect-fifth-you-can-see.md
+++ b/src/content/blog/a-perfect-fifth-you-can-see.md
@@ -1,7 +1,7 @@
 ---
 title: "A perfect fifth you can see"
 date: "2026-08-17"
-description: "An ear trainer where the background is not decoration: every note becomes a point source whose crest spacing is its real frequency, so a fifth locks into standing fringes and a tritone churns. Consonance stops being a word and becomes a picture."
+description: "An ear trainer that connects scale degrees to sound, with a wave illustration whose spacing follows the played notes’ frequency ratios."
 tags: ["Web Audio", "WebGL", "Music", "Physics", "TypeScript", "Game"]
 ---
 
@@ -10,6 +10,17 @@ Recognising an interval by ear is not knowledge. You cannot read your way to it.
 So I built one, and then I could not resist making the background do some physics.
 
 **[Try it](/demos/interval-trainer/)** — a chord, a note, ten buttons.
+
+## Before the buttons: what is an interval?
+
+An **interval** is a distance in pitch. The **root** is our reference note. In C major,
+C–D–E–F–G–A–B are degrees 1–7: E is degree 3 and G is degree 5. A degree number is
+not a count of semitones. A **semitone** is the step to the adjacent piano key,
+including black keys; C to E spans four, while C to G spans seven.
+
+Here `3b` means lower degree 3 by one semitone: E-flat when C is home. `4#` means
+raise degree 4: F-sharp. The octave is the next C, twelve semitones above the root.
+Try singing C–D–E, then compare C–E with C–E-flat before using the keypad.
 
 ## Two sounds, not three
 
@@ -54,15 +65,33 @@ $$
 u(\mathbf{r}, t) \;=\; \sum_i \operatorname{env}\!\left(t - \frac{r_i}{c}\right)\, s(r_i)\, \sin\!\left(\frac{2\pi\,(c\,t - r_i)}{\lambda_i}\right)
 $$
 
-One propagation speed $c$ for every ripple, exactly as in air. Pitch therefore changes *only* the crest spacing:
+Here $u$ is the displayed signed field, $i$ labels a sounding note, $r_i$ is distance
+from its source, $t$ is time since that note began, and $\lambda_i$ is crest spacing.
+The envelope $\operatorname{env}$ sets the note’s rise and decay; $s(r_i)$ fades it
+with distance. The displayed speed $c$ is in pixels per second, not metres per second.
+With one shared speed, higher pitch gives closer crests:
 
 $$
 \lambda_i \;=\; \lambda_0 \cdot \frac{f_\text{root}}{f_i}
 $$
 
-An octave's crests sit at half the root's. A fifth's sit at two thirds. And because those ratios are the real ones, the interference is the real thing too: a 3:2 pair sums into fringes that barely move, while a tritone never settles.
+An octave’s wavelength is half the root’s. The trainer uses twelve-tone equal temperament:
+seven semitones give a frequency ratio $2^{7/12}\approx1.4983$, close to a just fifth’s
+$3/2$. Its wavelength is therefore approximately, rather than exactly, two thirds of the
+root’s. A tritone spans six semitones and has ratio $\sqrt2$ in this tuning.
+[UNSW’s acoustics explanation](https://newt.phys.unsw.edu.au/jw/notes.html) connects these
+ratios to note names.
 
-That last contrast is sharper than I expected, and the reason is a nice piece of tuning arithmetic. Equal temperament's fifth is $2^{7/12} = 1.4983$, about two cents flat of a true $3{:}2$ — so the fringes do not stand perfectly still, they *drift*, slowly, like a beat you can watch. The tritone is $2^{1/2}$, which has no low-order rational neighbour worth the name; its pattern churns and never repeats. You can see the difference between the interval your ear finds restful and the one it finds restless, on the same screen, in the same second.
+The animation preserves these ratios at a slowed visual scale. It illustrates
+**superposition**: add the signed disturbances from the sources at each location.
+Two different frequencies do not form a stationary standing-wave pattern simply because
+their ratio is 3:2. Ideal sustained tones at a rational ratio repeat together after a
+common period; the decaying, spatially separated sources here add further changes.
+
+Nor is the picture a meter of consonance. The synthesized piano has several partials,
+while each visual source shows one wavelength. Harmonic relationships, the sound’s
+spectrum and musical context all matter to listening. Use the waves to compare spacing
+and addition, then use your ears to learn the interval.
 
 The rest of the field function is just honesty about a real wavefront. The envelope is evaluated at *retarded* time $t - r/c$, because what you see at radius $r$ left the source $r/c$ ago; amplitude falls as $\exp(-r/R)/\sqrt{1 + r/a}$, cylindrical spreading with a soft horizon so nothing ever reaches the far corner and sits there.
 
@@ -92,4 +121,4 @@ The answer clock starts when the target note *sounds*, and replaying does not re
 
 The pieces that decide whether it is any good — the interval table, question generation, the scoring constants, the highscore boards, the field function — are pure functions with tests that run as part of the build. Everything else is a canvas, an `AudioContext`, and ten buttons.
 
-Which is the whole pitch, really: the thing your ear is reaching for is drawn on the screen behind it, at the right wavelength, the whole time.
+The useful loop is simple: listen, choose, hear the answer, and try again. The waves make the frequency ratios visible; recognising the interval remains a listening skill.

--- a/src/content/projects/interval-trainer.ts
+++ b/src/content/projects/interval-trainer.ts
@@ -4,7 +4,7 @@ const project: ProjectMeta = {
   slug: 'interval-trainer',
   title: 'Interval Trainer',
   description:
-    'Ear training that shows its physics. Hear the root and fifth together, name the note that follows — while every note you hear ripples across the page at its own wavelength, and consonance becomes something you can see.',
+    'Ear training that shows its physics. Hear the root and fifth together, name the note that follows — while every note you hear ripples across the page at its own wavelength, in a slowed illustration of wave superposition.',
   tags: ['TypeScript', 'Web Audio', 'WebGL', 'Music', 'Game'],
   liveUrl: '/demos/interval-trainer/',
   repoUrl: 'https://github.com/andeplane/andeplane.github.io/tree/main/demos/interval-trainer',
@@ -37,15 +37,16 @@ best runs in the browser. There is a four-step tutorial for anyone who has never
 about intervals as numbers, and the key can be pinned to one note instead of drawn fresh
 each run.
 
-## Consonance you can see
+## Frequency ratios you can see
 
-The background is not decoration: it is the notes themselves, drawn. Each one becomes a
-point source, and the canvas shows their superposition, with a wavelength set by the note's
-own frequency — one speed for every ripple, exactly as in air, so pitch changes the spacing
-of the crests and nothing else. The fifth's crests sit at two thirds of the root's, an
-octave's at half. Because those ratios are the real ones, a simple interval sums into
-almost stationary interference fringes while the tritone's 45:32 never repeats and shimmers
-instead. The thing your ear is reaching for is on the screen behind it.
+Each sounding note creates a visual point source. Higher notes have shorter wavelengths,
+with spacing inversely proportional to frequency. An octave halves that spacing; the
+equal-tempered fifth is close to, but not exactly, a 3:2 frequency ratio.
+
+The sources add as signed waves at a slowed visual scale. This is an illustration of
+superposition, not a physical recording of the piano sound or a test of consonance.
+Start in Easy practice, keep one root, and compare a third with a fourth. Then try
+Medium to hear the major third (3) beside the minor third (3b).
 
 ## Under the hood
 

--- a/src/pages/Music.tsx
+++ b/src/pages/Music.tsx
@@ -57,7 +57,7 @@ export default function Music() {
           <h2 id="music-theory">The theory is part of the fun</h2>
           <p>
             I’m also interested in music theory and the things around music: recognising
-            intervals, understanding how notes fit together, and connecting what I hear
+            intervals — the distance in pitch between two notes — and understanding how notes fit together, and connecting what I hear
             with what I’m playing.
           </p>
           <p>
@@ -67,6 +67,21 @@ export default function Music() {
           </p>
         </section>
       </div>
+
+      <section className="no-article mt-8" aria-labelledby="music-first-listen">
+        <h2 id="music-first-listen">A first thing to listen for</h2>
+        <p>The root is the note we treat as home. Count C, D, E, F, G: G is the fifth
+          note of C major, so C to G is a fifth. C to the next C is an octave; its
+          frequency doubles. A semitone is one step between adjacent piano keys,
+          including the black keys, and twelve semitones make an octave.</p>
+        <p>In the trainer, listen to C and G together, then compare E with E-flat.
+          E is the major third, labelled 3; E-flat is one semitone lower, labelled 3b.
+          Start in Easy practice and replay before answering. The aim is to recognise
+          each note’s relationship to home, even when home changes.</p>
+        <p>In the tube lab, watch the pressure rather than a travelling parcel of air.
+          Air moves back and forth locally while the disturbance travels along the tube.
+          Compare the returning pulse with the far end open and capped.</p>
+      </section>
 
       <section className="mt-12" aria-labelledby="music-experiments">
         <p className="no-eyebrow">Listen, practise, experiment</p>

--- a/src/pages/Music.tsx
+++ b/src/pages/Music.tsx
@@ -57,7 +57,7 @@ export default function Music() {
           <h2 id="music-theory">The theory is part of the fun</h2>
           <p>
             I’m also interested in music theory and the things around music: recognising
-            intervals — the distance in pitch between two notes — and understanding how notes fit together, and connecting what I hear
+            intervals — the distance in pitch between two notes — understanding how notes fit together, and connecting what I hear
             with what I’m playing.
           </p>
           <p>

--- a/src/pages/Music.tsx
+++ b/src/pages/Music.tsx
@@ -76,7 +76,7 @@ export default function Music() {
           including the black keys, and twelve semitones make an octave.</p>
         <p>In the trainer, listen to C and G together, then compare E with E-flat.
           E is the major third, labelled 3; E-flat is one semitone lower, labelled 3b.
-          Start in Easy practice and replay before answering. The aim is to recognise
+          Start in Easy practice, then switch to Medium to include altered notes such as E-flat. Replay before answering. The aim is to recognise
           each note’s relationship to home, even when home changes.</p>
         <p>In the tube lab, watch the pressure rather than a travelling parcel of air.
           Air moves back and forth locally while the disturbance travels along the tube.


### PR DESCRIPTION
The Music page introduces root/fifth without defining an interval. The interval-trainer project and post claim unequal-frequency sources form stationary fringes and that a rational 45:32 tritone never repeats; the code uses equal temperament. The tutorial also needs a concrete scale-degree example.

Adds a C-major listening example and defines interval, root, degree, semitone and octave before the trainer notation. Rewrites the wave explanation around equal-tempered frequency ratios and signed superposition, defining the formula variables and separating the picture from perceived consonance. Updates the tutorial and field documentation to match.

Review: checked against the local interval table and wavelength calculation. No audio, rendering or scoring behavior changes. TypeScript and diff checks passed; the full site/demo CI gate will run on this PR.


Closes #40
