### PR TITLE
Correct ray-intersection guarantees and introduce the graphics vocabulary

### DIFF
--- a/demos/three-lefts/src/ui/menu.ts
+++ b/demos/three-lefts/src/ui/menu.ts
@@ -32,7 +32,7 @@ export function buildMenu(onPick: (level: LevelSpec) => void): HTMLElement {
 
   const sub = document.createElement('p')
   sub.className = 'menu__sub'
-  sub.textContent = 'Three houses that are honest about being impossible.'
+  sub.textContent = 'Eight houses with fixed rules and impossible geometry.'
 
   const cards = document.createElement('div')
   cards.className = 'cards'

--- a/src/content/blog/lunar-explorer-building-a-moon.md
+++ b/src/content/blog/lunar-explorer-building-a-moon.md
@@ -57,8 +57,8 @@ The renderer is where the Moon becomes the Moon:
 
 - **Normals from the heightfield gradient** feed a custom surface shader.
 - **Per-vertex ambient occlusion**, baked at generation time, darkens crater floors — cheap and surprisingly effective.
-- **A low sun angle** exaggerates relief; the terminator region is where lunar landscapes look best (every Apollo photo you remember was shot there).
-- **No atmospheric scattering.** This is the counterintuitive one: on Earth, distance means haze and a bright horizon. On the Moon there is no air, so the horizon *darkens* into black sky. Getting this wrong — adding the usual fog — instantly makes it look like a desert level. The absence of an effect is the effect.
+- **A low sun angle** exaggerates relief; the terminator region is where lunar landscapes look best (long shadows make small changes in height easier to read).
+- **No atmospheric scattering.** This is the counterintuitive one: on Earth, distance means haze and a bright horizon. The Moon has no substantial atmosphere to scatter sunlight into a bright sky. The sky stays black even beside sunlit terrain; the ground need not darken merely because it is distant. Getting this wrong — adding the usual fog — instantly makes it look like a desert level. The absence of an effect is the effect.
 
 ## What's next
 

--- a/src/content/blog/raytracing-from-sphere-to-quartic-torus.md
+++ b/src/content/blog/raytracing-from-sphere-to-quartic-torus.md
@@ -88,10 +88,10 @@ No trigonometry, no parametrisation, no UV seams — one gradient evaluated at t
 
 ## Finding quartic roots without crying
 
-Ferrari's closed-form quartic solution exists and is a numerical horror show in `float32` — catastrophic cancellation everywhere, exactly the precision GLSL gives you. The explorer takes the robust route instead, and makes it a lesson of its own:
+Ferrari’s closed-form quartic solution exists, but a direct floating-point implementation can lose accuracy through cancellation. Numerical root-finding has its own limitations. The explorer makes those tradeoffs a lesson:
 
 - **Scan + bisect:** march $t$ in small steps, watch for sign changes of $f$, then bisect each bracketing interval down to pixel precision. Bisection converges once a continuous function has been bracketed by opposite signs. The scan is the weak part: a tangent root need not change sign, and two crossings can hide inside one scan interval. A smaller step reduces that risk but does not certify all hits.
-- **Newton's method** as the comparison: $t_{n+1} = t_n - f(t_n)/f'(t_n)$ converges quadratically when it converges — and the explorer lets you watch it shoot off to the wrong root from an unlucky start, which teaches more about Newton than any theorem statement.
+- **Newton's method** as the comparison: $t_{n+1} = t_n - f(t_n)/f'(t_n)$ converges quadratically near a simple root when started sufficiently close — and the explorer lets you watch it shoot off to the wrong root from an unlucky start, which teaches more about Newton than any theorem statement.
 
 The torus is the sweet spot of this whole topic: rich enough to need real care (four roots! numerical traps!), small enough to fit on a napkin. Some higher-degree special cases still have exact solutions. Abel–Ruffini rules out a general formula by radicals for arbitrary quintics; it does not set a universal boundary on ray tracing. Non-polynomial implicit surfaces need other methods, and sphere tracing needs a suitable distance function or conservative distance bound.
 

--- a/src/content/blog/raytracing-from-sphere-to-quartic-torus.md
+++ b/src/content/blog/raytracing-from-sphere-to-quartic-torus.md
@@ -9,17 +9,24 @@ Deep inside every ray tracer — from a 1980s demo to a path tracer burning a re
 
 I built an [interactive explorer](https://andeplane.github.io/Raytracing/) for exactly that question, because the math deserves better than being scattered across textbook appendices. You pick a surface — sphere, cylinder, torus — and work through it in three tabs: the **Theory** derivation, an **Intuition** view where you drag the ray and watch the intersection polynomial deform live, and a **Code** tab with a live GLSL editor where your formulas render in real time. (The repo also ships a structured [student task](https://github.com/andeplane/Raytracing) — derive on paper, implement in GLSL, watch it appear.)
 
-This post is the theory tab, in blog form.
+This post develops the sphere first, then reuses the same substitution for a cylinder
+and a torus. You need vector dot products and the quadratic formula; the gradient
+below is a vector of partial derivatives, pointing perpendicular to a smooth surface.
+
+A **ray** starts at $\mathbf O$ and travels in direction $\mathbf D$. The parameter
+$t$ measures distance along it when $\mathbf D$ has unit length. An **implicit surface**
+is the set of points where a function $F$ is zero. The task is to find where the ray
+makes that function zero.
 
 ## The recipe
 
-Every analytic ray–surface intersection is the same three moves:
+For the polynomial surfaces used here, the recipe has three moves:
 
 1. **Write the surface implicitly:** $F(\mathbf{p}) = 0$.
 2. **Substitute the ray** $\mathbf{P}(t) = \mathbf{O} + t\mathbf{D}$ (with $\lVert\mathbf{D}\rVert = 1$) to get a 1D polynomial $f(t) = 0$.
 3. **Take the smallest positive root** $t^\ast$; the hit point is $\mathbf{P}(t^\ast)$ and the surface normal is the gradient, $\hat{\mathbf{N}} = \nabla F / \lVert\nabla F\rVert$, evaluated there.
 
-The *degree* of the polynomial is the geometry's personality: it's the maximum number of times a straight line can pierce the surface.
+A nonzero degree-$d$ polynomial has at most $d$ real roots, counting multiplicity. Some may lie behind the ray, and a tangent can touch without crossing. A line lying entirely in a surface is a separate, degenerate case.
 
 ## Warm-up: the sphere (degree 2)
 
@@ -34,6 +41,11 @@ A quadratic — a line can cross a sphere at most twice. The same result has a b
 ![Ray–sphere intersection, geometrically](/blog/raytracing/ray-sphere.svg)
 
 *Project the centre onto the ray to get $t_{ca}$, use Pythagoras to get the miss distance $d$, then Pythagoras again inside the sphere for the half-chord. The discriminant of the quadratic and the test $d > R$ are the same fact wearing different clothes.*
+
+For a worked check, take $R=1$, $\mathbf O=(0,0,-3)$ and $\mathbf D=(0,0,1)$.
+The equation becomes $t^2-6t+8=0$, giving $t=2$ and $t=4$: the front and back of
+the sphere. Choose $t=2$. If the camera starts inside, discard the negative root and
+keep the forward exit. A zero discriminant is a tangent, not a miss.
 
 The normal is $\nabla F = 2\mathbf{p}$ — pointing radially out, as it must.
 
@@ -78,10 +90,15 @@ No trigonometry, no parametrisation, no UV seams — one gradient evaluated at t
 
 Ferrari's closed-form quartic solution exists and is a numerical horror show in `float32` — catastrophic cancellation everywhere, exactly the precision GLSL gives you. The explorer takes the robust route instead, and makes it a lesson of its own:
 
-- **Scan + bisect:** march $t$ in small steps, watch for sign changes of $f$, then bisect each bracketing interval down to pixel precision. Boring, bulletproof, and easily good enough at fragment-shader rates.
+- **Scan + bisect:** march $t$ in small steps, watch for sign changes of $f$, then bisect each bracketing interval down to pixel precision. Bisection converges once a continuous function has been bracketed by opposite signs. The scan is the weak part: a tangent root need not change sign, and two crossings can hide inside one scan interval. A smaller step reduces that risk but does not certify all hits.
 - **Newton's method** as the comparison: $t_{n+1} = t_n - f(t_n)/f'(t_n)$ converges quadratically when it converges — and the explorer lets you watch it shoot off to the wrong root from an unlucky start, which teaches more about Newton than any theorem statement.
 
-The torus is the sweet spot of this whole topic: rich enough to need real care (four roots! numerical traps!), small enough to fit on a napkin. Past degree 4 the analytic road ends — Abel–Ruffini says quintics have no general closed form — and ray tracing switches to iterative machinery like sphere tracing over signed distance fields. The quartic torus is the last surface you can conquer *exactly*.
+The torus is the sweet spot of this whole topic: rich enough to need real care (four roots! numerical traps!), small enough to fit on a napkin. Some higher-degree special cases still have exact solutions. Abel–Ruffini rules out a general formula by radicals for arbitrary quintics; it does not set a universal boundary on ray tracing. Non-polynomial implicit surfaces need other methods, and sphere tracing needs a suitable distance function or conservative distance bound.
+
+Try a grazing ray, then a ray through both sides of the torus. Predict the number of
+forward intersections before looking at the graph. Ask whether the numerical search
+found every root you expected. [PBRT’s sphere derivation](https://pbr-book.org/4ed/Shapes/Spheres)
+shows how a production renderer turns the same mathematics into intersection tests.
 
 ## Full circle
 

--- a/src/content/blog/three-lefts-a-house-whose-loops-do-not-close.md
+++ b/src/content/blog/three-lefts-a-house-whose-loops-do-not-close.md
@@ -25,6 +25,11 @@ That is the one decision everything else falls out of, and it is worth stating a
 
 What exists instead is a graph. Rooms are nodes, each with its own private copy of ℝ³ and its own origin. Doorways are edges, and each edge is labelled with a rigid transform. The player's position is always `(cell, local x, local z)` — a room, and where you are inside it. Walking through a door multiplies you by that door's transform and hands you a new room to be in.
 
+A **rigid transform** changes coordinates by a rotation and a translation, preserving
+local lengths and angles. Compose transforms by applying the rightmost one first.
+The **identity** transform means no change. These definitions let us compare a closed
+walk through the room graph with the position a flat map predicts.
+
 The transform itself is short. Give every doorway a frame `F` sitting at the opening's centre with `+Z` pointing into the room it belongs to. Then the coordinate change from room A to room B is
 
 ```
@@ -47,7 +52,7 @@ Make it anything other than the identity and the loop refuses to close.
 
 **Every impossibility in the game is that one statement and nothing else.** There is no second trick. A ring of three rooms, each of which you enter from the south and leave by the west — one left turn apiece — closes as a graph after 270° of turning, so three lefts bring you home and space is smaller than it should be. A ring of five closes after 450°, so four lefts are *not enough*, and hidden in that excess is a room Euclidean geometry has nowhere to put. That room is where the good stuff is.
 
-The quantity is the angle defect, `δ = 2π − nθ`, and it is the same object a cosmologist means by a cone point.
+The accumulated angular mismatch is `δ = 2π − nθ`, where n counts turns and θ is each turn’s angle. It resembles the angle deficit around a cone, but a doorway-connected loop does not by itself create a cone point you can stand on.
 
 ## The part I got wrong
 
@@ -71,7 +76,7 @@ The first three levels teach the vocabulary — angle defect, a corridor glued t
 
 In all three, the notebook is the tell. It draws what you believe — flat, Euclidean, dead-reckoned — and it visibly fails: it spirals into itself around a deficit, and leaves a wedge of blank paper around an excess.
 
-The later levels take that away. A ring of **eight** rooms turns 720°, so after four lefts your map has drawn a flawless square, closed it, and told you that you are exactly where you began. You are one room short of it, in a room you have never been in, and the map is not merely wrong — it is confidently, consistently, provably wrong, which is worse and far harder to catch. The only instrument that still works is chalk.
+The later levels take that away. A ring of **eight** rooms turns 720°, so after four lefts your map has drawn a flawless square, closed it, and told you that you are exactly where you began. You are halfway around the eight-room ring, in a different room, and the map is not merely wrong — it is confidently, consistently, provably wrong, which is worse and far harder to catch. The only instrument that still works is chalk.
 
 Then a single glasshouse whose four doorways lead back into itself. Four norths compose to precisely nothing; so do four wests. But north-then-west and west-then-north land 27 metres apart, and the commutator `n·w·n⁻¹·w⁻¹` comes out as a pure translation of about 28 metres with no rotation at all. Two loops that each close, and whose order matters. That one is not drawable.
 
@@ -79,9 +84,9 @@ Then a single glasshouse whose four doorways lead back into itself. Four norths 
 
 The renderer draws the world by recursive stencil passes — mark the doorway, reset the depth inside it, recurse with the transformed camera, stamp the depth back, unmark. Three levels deep, which on the busiest level is fourteen full renders of shaded geometry per frame.
 
-The constraint that shapes everything is that **no screen-space technique may sample across a portal boundary**. SSAO, SSR, TAA, screen-space shadows — all of them read neighbouring pixels, and across a doorway edge the neighbouring pixel is in a different room. They smear and ghost at exactly the seam the player is staring at, which is the one place the whole illusion has to hold. So the cheap route to looking good is closed, and the look has to come from baked vertex AO, a purpose-built environment map, and MSAA, the only anti-aliasing that qualifies.
+The constraint that shapes everything is that **no screen-space technique may sample across a portal boundary**. SSAO, SSR, TAA, screen-space shadows — all of them read neighbouring pixels, and across a doorway edge the neighbouring pixel is in a different room. They smear and ghost at exactly the seam the player is staring at, which is the one place the whole illusion has to hold. So the cheap route to looking good is closed, and the look has to come from baked vertex AO, a purpose-built environment map, and MSAA, which smooths geometry edges. Supersampling is another option; screen-space methods need explicit portal-boundary handling.
 
-Sound obeys the same graph. Audio travels the portal edges rather than any space the rooms sit in, so a lantern two rooms away arrives from the direction the *graph* says. The listener is nailed to the origin and every source is placed in head coordinates, because the vector from your head to a sound is the only frame a portal transform leaves unchanged: crossing a doorway rotates the source and the head by the same amount, and the difference is untouched. Measured across a real crossing, the apparent position moves 8 cm — against 17 cm for an ordinary walking frame. No seam.
+Sound obeys the same graph. Audio travels the portal edges rather than any space the rooms sit in, so a lantern two rooms away arrives from the direction the *graph* says. The listener is nailed to the origin and every source is placed in head coordinates, because the sound is expressed relative to the listener’s position and orientation: crossing a doorway transforms both source and listener; expressing the relative vector in the transformed head basis preserves its components. Measured across a real crossing, the apparent position moves 8 cm — against 17 cm for an ordinary walking frame. No seam.
 
 And it pays off in the shrine. From all three barred windows the lantern reads at the same distance and the same bearing — five metres, ninety degrees right, through one barred doorway. You can prove three windows look into one room with your ears, from inside a room you cannot leave.
 

--- a/src/content/projects/lunarlander.ts
+++ b/src/content/projects/lunarlander.ts
@@ -23,7 +23,7 @@ The Three.js scene uses a custom lunar surface shader with:
 - Normal map derived from the heightfield gradient
 - Ambient occlusion baked per-vertex at generation time
 - Directional sunlight at a low angle to exaggerate surface relief
-- Atmospheric haze that matches the Moon's lack of atmosphere (the horizon darkens rather than brightens)
+- No Earth-like atmospheric haze: the terrain meets a black sky, with distance cues supplied by geometry and lighting
 
 ## Performance
 

--- a/src/content/projects/raytracing.ts
+++ b/src/content/projects/raytracing.ts
@@ -19,9 +19,16 @@ Choose a geometry — **sphere**, **cylinder**, or **torus** — and explore ray
 
 ## The core idea
 
-Every analytic ray–surface intersection follows the same three steps: write the implicit surface equation F(**p**) = 0, substitute the ray **P**(t) = **O** + t**D** to get a polynomial f(t) = 0, then find the smallest positive root and evaluate the normal **N** = normalize(∇F) at the hit point.
+For the algebraic surfaces in this explorer, the intersection follows three steps: write the implicit surface equation F(**p**) = 0, substitute the ray **P**(t) = **O** + t**D** to get a polynomial f(t) = 0, then find the smallest positive root and evaluate the normal **N** = normalize(∇F) at the hit point.
 
 The torus is the centrepiece because it produces a **degree-4 (quartic)** polynomial — a ray can pierce it at up to four points — making it the richest analytic case before you reach general implicit surfaces. The sphere and cylinder (both quadratic) serve as warm-ups.
+
+Here **O** is the ray origin, **D** its direction, and t its forward distance when D is
+unit length. A root is a value of t that lands on the surface. The gradient ∇F points
+perpendicular to that surface; normalizing it gives a unit lighting direction.
+Start with a unit sphere viewed from (0, 0, −3) along +z: the hits are t = 2 and t = 4.
+Then move the ray until the two hits meet at a tangent. A sign-change scan can miss
+that tangent, so numerical root finding is part of the lesson too.
 
 ## For students
 

--- a/src/content/projects/sunken.ts
+++ b/src/content/projects/sunken.ts
@@ -17,8 +17,7 @@ island. No combat, no oxygen meter, no way to lose — the reward loop is discov
 
 The whole world is a single analytic function. \`field(x, y, z)\` returns signed density —
 positive inside rock — and it drives terrain meshing, player collision, prop scattering
-and cave validation alike. There is no collider mesh, so the visible world and the
-collidable world *cannot* drift apart. The Gerstner wave table is treated the same way:
+and cave validation alike. There is no collider mesh, so rendering and collision share the same underlying surface definition. The displayed mesh is still a finite-resolution approximation, so local differences need checking. The Gerstner wave table is treated the same way:
 one definition, evaluated in the shader for the surface and in JavaScript for boat
 buoyancy and the waterline test.
 
@@ -40,6 +39,10 @@ meshes it at 0.6 m across a worker pool, baking per-vertex sky visibility as it 
 which then does a surprising amount of work: caves go genuinely dark, caustics are masked
 so they cannot leak onto cave ceilings, and flora only grows where light reaches.
 
+A **signed density field** tells us which side of a surface a point is on. Marching
+cubes samples that field on a grid and builds triangles where its sign changes.
+Smaller grid cells capture finer caves but require more triangles and computation.
+
 ## Water
 
 Extinction is a vec3, not a scalar. Red dies in a few metres while blue survives tens, so
@@ -48,7 +51,7 @@ cannot do, and whose absence is why most underwater scenes just look blue-hazed.
 the green-to-blue ratio wrong is what makes water read as teal instead of ocean.
 
 Seen from below, the surface produces Snell's window: a 96° cone of refracted sky ringed
-by total internal reflection. Caustics are real — sunbeams refracted through the wave
+by total internal reflection. Caustics — the moving bright patterns on the seabed — are modeled as sunbeams refracted through the wave
 surface and projected down, with brightness from how much each beam's footprint
 compressed, measured with screen-space derivatives. The volumetric light shafts are
 modulated by that same caustic map, so the beams and the pattern they cast on the sand
@@ -58,11 +61,10 @@ come from one source and actually line up.
 
 Fish schools and gulls run one GPU flocking system on compute shaders, split into
 per-school buffers — six schools of five hundred interacting only within themselves rather
-than one flock of thousands, a roughly 45× reduction in the O(N²) inner loop. Crabs walk
+than one flock of thousands, a reduction in pair checks from roughly (6 × 500)² to 6 × 500² — about sixfold for those fish schools. Actual frame cost includes other work. Crabs walk
 the seabed as CPU agents with legs animated procedurally from baked vertex attributes, all
 in a single draw call. Some fifty thousand instanced corals, kelp and sponges sway in the
-surge, coloured by rotating each instance around the hue wheel rather than lerping between
-two colours — a lerp between crimson and gold passes through mud.
+surge, coloured by rotating each instance around the hue wheel rather than linearly interpolating between two colours. The hue rotation is an artistic choice that keeps the palette vivid.
 
 Somewhere in the deepest chamber there is a chest.
 

--- a/src/content/projects/three-lefts.ts
+++ b/src/content/projects/three-lefts.ts
@@ -66,8 +66,7 @@ The governing constraint is that **no screen-space technique may sample across a
 boundary**. SSAO, SSR, TAA and screen-space shadows all read neighbouring pixels, and
 across a doorway edge the neighbouring pixel is in a different room; they smear and ghost
 at exactly the seam the player is staring at. That rules out the cheap route to looking
-good, so the look comes from baked vertex AO, a purpose-built environment map, and MSAA —
-the only anti-aliasing that qualifies.
+good, so the look comes from baked vertex AO, a purpose-built environment map, and MSAA (multisample anti-aliasing), which smooths geometry edges without borrowing a neighboring room’s pixels.
 
 Sound obeys the same graph. Audio travels the portal edges rather than any space the rooms
 sit in, so a lantern two rooms away arrives from the direction the *graph* says. The

--- a/src/pages/Rendering.tsx
+++ b/src/pages/Rendering.tsx
@@ -108,10 +108,10 @@ export default function Rendering() {
       <section className="no-article mt-8" aria-labelledby="rendering-billboards">
         <h2 id="rendering-billboards">The sphere is two triangles</h2>
         <p>
-          One of my favourite tricks is billboarding. For each atom, draw a small quad that
+          One of my favourite tricks is billboarding. For each atom, draw a small quad — a flat rectangle made of two triangles — that
           faces the camera. It covers the part of the screen where the sphere will appear.
-          For each pixel in that quad, a fragment shader asks whether the viewing ray hits
-          the sphere. Misses are discarded; hits give a surface position and a normal for lighting.
+          For each pixel in that quad, a fragment shader — a small GPU program that computes the pixel’s appearance — asks whether the viewing ray hits
+          the sphere. Misses are discarded; hits give a surface position and a normal, the direction perpendicular to the surface, for lighting.
         </p>
         <p>
           The crucial detail is depth: write the depth of the sphere’s surface, rather than


### PR DESCRIPTION
The ray-tracing article calls scan-and-bisect bulletproof, although tangencies and two roots inside a scan interval can be missed. It implies every implicit surface becomes a polynomial and that quartics are the last exactly solvable surfaces. The rendering page uses quad, shader and normal without introductions. Three Lefts claims MSAA is the only valid anti-aliasing and miscounts the halfway point of an eight-room loop; its menu still says three houses. Lunar/Sunken descriptions also confuse stylized rendering choices with physical guarantees.

Adds the ray origin/direction/root vocabulary and a numerical sphere example, explains scan-and-bisect failure cases, and bounds the polynomial claims. Defines quad/shader/normal on the rendering page. Corrects Three Lefts' room count and portal-coordinate explanation, lunar lighting language, and Sunken's six-school pair-count arithmetic and finite-mesh caveat.

Review: checked the worked sphere roots (2 and 4), the eight-room loop definitions, and the six-school complexity calculation. TypeScript and diff checks passed. Simulation algorithms are unchanged; CI builds the site and all demos.


Closes #41
