### PR TITLE
Explain Enigma stepping and decryption without the odometer misconception

### DIFF
--- a/src/content/blog/enigma-build-the-machine-to-understand-it.md
+++ b/src/content/blog/enigma-build-the-machine-to-understand-it.md
@@ -15,21 +15,23 @@ Press a key and a current runs through: the plugboard $S$ (a handful of user-con
 
 ![One keypress, seven permutations and a reflection](/blog/enigma/signal-path.svg)
 
-*The full journey of one keypress. Before the signal even enters, the fast rotor steps — the machine never encrypts two letters with the same configuration.*
+*The full journey of one keypress. Before the signal even enters, the fast rotor steps — successive keypresses use different rotor positions, until the stepping cycle repeats.*
 
-Every component is just a permutation of 26 letters, so one keypress computes:
+A **permutation** rearranges the letters without losing or duplicating any: for example, A → C, B → A, C → B is a permutation of a three-letter alphabet. Every Enigma component permutes 26 letters. At one fixed rotor position, the complete signal path computes:
 
 $$
 E \;=\; S^{-1} R^{-1} M^{-1} L^{-1} \, U \, L M R S
 $$
 
-read right-to-left: plugboard, three rotors, reflector, and back out through the same components inverted. The rotors rotate between keypresses — the fast rotor every time, the middle rotor once per 26, like an odometer — so $E$ is different for every letter of the message. That's the machine's whole strength: a polyalphabetic cipher with period 26³ = 17,576, mechanically generated.
+Read right-to-left: plugboard, three rotors, reflector, and back out through the same components inverted. The superscript −1 means undoing a permutation. The wiring stays fixed, but stepping changes which contacts meet, so the substitution changes during a message.
+
+The stepping mechanism is **not an odometer**. The right rotor steps every press. Its turnover notch lets a pawl advance the middle rotor; when the middle rotor is itself at its notch, the next press advances both it and the left rotor. The middle rotor can therefore step on two consecutive presses. For the usual three moving, single-notch rotors this double-step gives a cycle of 16,900 presses, rather than all 26³ possible positions. [David Hamer’s analysis of the stepping mechanism](https://www.cryptomuseum.com/people/hamer/files/double_stepping.pdf) explains the mechanical reason.
 
 **Implementation one** (`enigma_python.py`) says exactly this in code: rotors are lookup tables with index arithmetic, rotation is an offset, the notch mechanism advances the neighbour. It reads like the machine's manual, and it's the version to open if you want to *follow the current*.
 
 ## Then write it again, as linear algebra
 
-**Implementation two** (`enigma_matrix.py`) represents every component as a 26×26 **permutation matrix** — a single 1 in each row and column. Encrypting letter $x$ (as a one-hot vector $\mathbf{e}_x$) is a chain of matrix multiplications; rotating a rotor is conjugating it with the cyclic-shift matrix $C$: after $k$ steps, the rotor's effective permutation is $C^{-k} R\, C^{k}$.
+**Implementation two** (`enigma_matrix.py`) represents every component as a 26×26 **permutation matrix** — a single 1 in each row and column. A **one-hot vector** represents a letter by putting 1 in its position and 0 everywhere else: A is (1, 0, …), B is (0, 1, …). Encrypting letter $x$, represented by $\mathbf{e}_x$, is a chain of matrix multiplications; rotating a rotor is conjugating it with the cyclic-shift matrix $C$: after $k$ steps, the rotor's effective permutation is $C^{-k} R\, C^{k}$.
 
 This sounds like a party trick — NumPy cosplay. It isn't. The matrix formulation makes the machine's two most famous properties fall out as one-liners.
 
@@ -39,7 +41,7 @@ $$
 E^2 = P^{-1} U P \, P^{-1} U P = P^{-1} U^2 P = I
 $$
 
-Type ciphertext into an identically-configured machine and the plaintext comes out. Operationally elegant — one machine, one procedure, both directions. The web demo lets you verify this: encrypt anything, feed the output back with the same key, watch your message reappear.
+This identity applies at a **fixed rotor state**. To decrypt a whole message, restore the same rotor order, ring settings, plugboard and **starting rotor positions** used before encryption, then type the ciphertext. Both runs follow the same stepping sequence. Try a short message, reset those positions, and feed the output back: your message should reappear. Continuing from the final positions would use a different sequence.
 
 **Property 2: no letter ever encrypts to itself.** The reflector pairs *distinct* letters, so $U$ has zeros on its diagonal. Conjugation by a permutation matrix just relabels which letter is which — it shuffles the diagonal entries but can't create new ones. Cleanest way to see it: the trace is invariant under conjugation,
 
@@ -49,14 +51,14 @@ $$
 
 and for a permutation matrix, the trace *counts fixed points*. Zero trace, zero fixed points: **pressing A can light up any lamp except A.**
 
-That innocent-looking guarantee is the crack in the armour. It leaks information with every keystroke: any alignment where a guessed plaintext word ("WETTERBERICHT" — the weather report sent at the same time every morning) would require some letter to encrypt to itself is *impossible* and can be discarded. Bletchley's cribs and the Bombe's search were built directly on this. The feature that made the machine convenient — the reflector that made it an involution — is precisely what made it breakable.
+That innocent-looking guarantee is the crack in the armour. It leaks information with every keystroke: any alignment where a guessed plaintext word ("WETTERBERICHT" — the weather report sent at the same time every morning) would require some letter to encrypt to itself is *impossible* and can be discarded. This constraint helped reject crib alignments. It was one ingredient in a much larger cryptanalytic effort involving Polish breakthroughs, intercepted traffic, operator practices, guessed plaintext and mechanized searches. The reflector provides a useful weakness to understand; the equation alone is not a method for recovering a key.
 
 I knew that story from books. But deriving $\mathrm{tr}(E) = 0$ myself, from a design decision I had just implemented, was the first time it felt *obvious* — the flaw isn't a subtle oversight, it's algebraically forced by the reflector.
 
 ## The engineering bit
 
-Both implementations sit behind shared abstract interfaces (`Rotor`, `Reflector`, `Plugboard`), so either can be swapped into the `EnigmaMachine` orchestrator. The test suite drives both with the same key settings and historical test vectors and requires identical output — each implementation debugs the other. A misunderstanding of the stepping mechanism (the infamous double-step of the middle rotor) shows up instantly as a divergence between the two.
+Both implementations sit behind shared abstract interfaces (`Rotor`, `Reflector`, `Plugboard`), so either can be swapped into the `EnigmaMachine` orchestrator. The test suite drives both with the same key settings and historical test vectors and requires identical output — each implementation debugs the other. Independent implementations can reveal different coding mistakes. Agreement alone cannot rule out a shared misconception, so historical test vectors and explicit double-step cases matter too.
 
-And the key space, for the record: 60 rotor orders × 17,576 rotor positions × ~150 trillion plugboard configurations ≈ **1.6 × 10²⁰ keys**. The Germans concluded it was unbreakable by enumeration, and they were right — the Allies never enumerated it. They used the algebra above instead.
+And the key space, for the record: 60 rotor orders × 17,576 rotor positions × ~150 trillion plugboard configurations ≈ **1.6 × 10²⁰ keys**. That illustrative count fixes assumptions about the machine and plugboard and is not the stepping period. The successful attacks reduced the search using machine structure and message evidence; they did not simply try every key or apply the trace identity by itself.
 
 The best way to learn is to build. The second-best way is to build it *twice*.

--- a/src/content/projects/enigma.ts
+++ b/src/content/projects/enigma.ts
@@ -9,23 +9,23 @@ const project: ProjectMeta = {
   repoUrl: 'https://github.com/andeplane/enigma.py',
   screenshot: '/projects/enigma/preview.png',
   longDescription: `
-A historically faithful Enigma machine emulator implemented in Python, with two distinct internal approaches that illuminate the mathematics behind the cipher.
+Enigma replaces each typed letter with another letter, then moves its rotors so the next substitution changes. This Python emulator models that mechanical cipher in two ways, letting the same signal path be followed as wiring or as mathematics.
 
 ## Two implementations, one interface
 
 **Python implementation** (\`enigma_python.py\`) — uses straightforward index arithmetic to simulate rotor wiring and rotation. Each rotor applies a character substitution via lookup, and the notch mechanism advances neighbouring rotors. Clear, readable, and educational.
 
-**Matrix implementation** (\`enigma_matrix.py\`) — represents every rotor, reflector, and plugboard as a 26×26 NumPy permutation matrix. Encryption is a chain of matrix multiplications; rotation is a permutation of rows and columns. This framing makes it obvious why the Enigma is its own inverse (the product of all matrices is an involution).
+**Matrix implementation** (\`enigma_matrix.py\`) — represents every rotor, reflector, and plugboard as a 26×26 NumPy permutation matrix. Encryption is a chain of matrix multiplications; rotation is a permutation of rows and columns. A permutation matrix rearranges letter positions. At a fixed rotor state, the outgoing path, paired-letter reflector and reversed return path together form an involution: applying that substitution twice gives the original letter.
 
 ## Architecture
 
 Abstract base classes define \`Rotor\`, \`Reflector\`, and \`Plugboard\` interfaces, so either implementation can be swapped in without touching the \`EnigmaMachine\` orchestrator. Both implementations produce identical output for the same key settings.
 
-A web interface compiled to WebAssembly is hosted on GitHub Pages — try encrypting a message and then decrypting the ciphertext with the same key to verify the involution property.
+A web interface compiled to WebAssembly is hosted on GitHub Pages — try encrypting a message and then decrypting the ciphertext with the same settings **after resetting the rotors to their starting positions**. This repeats the same sequence of substitutions and recovers the original message.
 
 ## Why it's interesting
 
-The matrix framing makes it easy to see why the Germans believed Enigma was unbreakable (the key space is enormous) and why it had the fatal flaw the Allies exploited (no letter can encrypt to itself, because the diagonal of the combined matrix is always zero).
+The reflector makes it impossible for a letter to encrypt to itself. That constraint can reject a guessed plaintext alignment, but it does not recover the key on its own. The accompanying article derives the constraint and explains why changing rotor positions, including the middle rotor’s double-step, must be treated separately from the fixed-state algebra.
   `.trim(),
 }
 


### PR DESCRIPTION
The Enigma post says the middle rotor steps every 26 presses with period 26^3, then mentions double-stepping later. It tells readers to feed ciphertext back with the same key without explicitly resetting rotor positions. It overstates a single algebraic property as the whole historical break.

Introduces permutations and one-hot vectors, explains notch-driven double stepping, and separates fixed-state inversion from resetting a message. Bounds the cryptanalytic account and distinguishes independent implementations from historical test evidence.

Validation: reviewed the algebra and stepping explanation against Hamer’s mechanical analysis; `git diff --check`. Changes affect site copy only.


Closes #42
