### PR TITLE
Make Grover's oracle, real amplitudes and rotation coordinates explicit

### DIFF
--- a/demos/grover/src/essay/Amplitudes101.tsx
+++ b/demos/grover/src/essay/Amplitudes101.tsx
@@ -34,10 +34,14 @@ export function Amplitudes101() {
           moment, is <em>at</em> one box. A quantum computer instead keeps a number for{' '}
           <em>every</em> box at once — called an <strong>amplitude</strong> — and this is
           the whole data structure. Four boxes, four amplitudes. A million boxes, a million
-          amplitudes.
+          amplitudes in its mathematical description. This browser simulator stores that
+          array explicitly. A quantum device uses qubits: q qubits have 2ᑫ basis states,
+          but measuring them does not let you read out the whole array.
         </p>
         <p>
-          Two rules govern these numbers. First: when you <em>measure</em> — when you
+          General amplitudes are complex numbers, with probability |a|². This Grover
+          construction stays real, so signed bars and ordinary squares are sufficient.
+          Two rules govern these real numbers. First: when you <em>measure</em> — when you
           finally look — you get exactly one box, at random, and the probability of getting
           box <M>i</M> is its amplitude squared:
         </p>

--- a/demos/grover/src/essay/BreakIt.tsx
+++ b/demos/grover/src/essay/BreakIt.tsx
@@ -17,7 +17,7 @@ export function BreakIt() {
         <p>
           Give it an oracle that <strong>marks nothing</strong>, and diffusion has nothing
           to bite on: the uniform state's mean is the uniform state, reflection fixes every
-          bar in place, and the algorithm politely spins forever at{' '}
+          bar in place, and the state stays fixed, with each box still at{' '}
           <span style={{ whiteSpace: 'nowrap' }}>P = 1/N</span>. Give it an oracle that
           confidently <strong>marks the wrong box</strong>, and the machine works
           flawlessly — amplifying the wrong box to near-certainty. Grover's algorithm is

--- a/demos/grover/src/essay/Closing.tsx
+++ b/demos/grover/src/essay/Closing.tsx
@@ -15,11 +15,11 @@ export function Closing() {
           <M>{String.raw`\Omega(\sqrt N)`}</M> oracle calls. Quadratic is not nothing; it
           is also not the sci-fi version. Searching an exponentially large haystack —
           say, all <M>{String.raw`2^{128}`}</M> AES keys — still takes{' '}
-          <M>{String.raw`2^{64}`}</M> quantum steps. Grover does not "break encryption";
-          it halves the effective key length, which is why the practical response was not
-          panic but AES-256. And each "step" here is a full, coherent, error-corrected run
-          of the oracle circuit — plausibly slower per step than classical hardware by
-          enough to eat the advantage for any N a datacenter could brute-force anyway.
+          on the order of <M>{String.raw`2^{64}`}</M> oracle queries in the idealized
+          search model. This is a query count, not a runtime estimate: reversible key
+          checking, error correction and available hardware all have costs. Doubling
+          key length offsets this square-root scaling in that model; it does not by
+          itself establish a practical attack or a complete security assessment.
         </p>
         <p>
           What the algorithm actually is, is something better than a product pitch: the

--- a/demos/grover/src/essay/TheCircuit.tsx
+++ b/demos/grover/src/essay/TheCircuit.tsx
@@ -10,7 +10,7 @@ export function TheCircuit() {
       <Prose>
         <p>
           Everything so far could be accused of being a cartoon. So here is the third
-          altitude: real gates on real qubits, no shortcuts. Three qubits give{' '}
+          altitude: a classical simulation of quantum gates on three qubits. Three qubits give{' '}
           <M>{String.raw`2^3 = 8`}</M> basis states — our eight boxes; "box 5" is the
           bitstring <M>{String.raw`|101\rangle`}</M>. Only three gate types appear:{' '}
           <strong>H</strong> (the Hadamard, which builds and unbuilds superpositions),{' '}

--- a/demos/grover/src/essay/TheOracle.tsx
+++ b/demos/grover/src/essay/TheOracle.tsx
@@ -27,7 +27,9 @@ export function TheOracle() {
           First, what does "checking a box" even mean in superposition? The yes/no check
           is given to us as a circuit — the <strong>oracle</strong>. Fed a single box, it
           can reversibly write its answer into an extra qubit. Preparing that qubit in
-          the minus state converts the answer into a phase change, called phase kickback.
+          the minus state — equal amplitudes for 0 and 1 with opposite signs — converts
+          a yes answer into a sign change. Flipping that extra qubit exchanges those
+          amplitudes, multiplying the branch by −1. This is phase kickback.
           The resulting phase oracle{' '}
           <strong>flips the sign of the marked box's amplitude</strong> and leaves every
           other box alone.

--- a/demos/grover/src/essay/TheOracle.tsx
+++ b/demos/grover/src/essay/TheOracle.tsx
@@ -26,13 +26,17 @@ export function TheOracle() {
         <p>
           First, what does "checking a box" even mean in superposition? The yes/no check
           is given to us as a circuit — the <strong>oracle</strong>. Fed a single box, it
-          answers yes or no, exactly like the classical check. Fed a superposition, it does
-          the only thing a quantum circuit can do with a yes: it{' '}
+          can reversibly write its answer into an extra qubit. Preparing that qubit in
+          the minus state converts the answer into a phase change, called phase kickback.
+          The resulting phase oracle{' '}
           <strong>flips the sign of the marked box's amplitude</strong> and leaves every
           other box alone.
         </p>
         <p>
           Click a bar below to choose where the prize hides, then apply the oracle.
+          We wire in the answer here to demonstrate the transformation. In a search
+          problem, the circuit instead tests a property — such as whether a candidate
+          satisfies some constraints — without needing the successful candidate in advance.
         </p>
       </Prose>
       <WidgetFrame
@@ -75,8 +79,9 @@ export function TheOracle() {
           Now the disappointment, which is really the plot. Look at the probabilities:{' '}
           <strong>nothing happened.</strong> Every box still measures at{' '}
           <M>1/8</M>, because squaring erases the sign. The oracle has secretly branded the
-          winner — its amplitude now points the other way — but no measurement can see a
-          lone sign. The information is in the state; it is just invisible.
+          winner — its amplitude now points the other way — but measuring the box label
+          in this basis cannot reveal that relative sign. Other measurement bases can;
+          diffusion makes the difference visible in the box probabilities.
         </p>
         <p>
           Invisible, that is, until something <em>compares amplitudes to each other</em>.

--- a/demos/grover/src/essay/TwoMirrors.tsx
+++ b/demos/grover/src/essay/TwoMirrors.tsx
@@ -13,11 +13,16 @@ export function TwoMirrors() {
         <p>
           Time to climb to the second altitude. Sixteen bars are really only{' '}
           <em>two</em> numbers in disguise: the amplitude of the marked box, and the
-          amplitude shared by all the identical unmarked ones. So the entire state lives in
+          amplitude shared by all the unmarked ones. That equality is preserved by
+          these operations from a uniform start; an arbitrary state need not have it.
+          For this run, the entire state lives in
           a flat plane. Put the marked direction <M>{String.raw`|\alpha\rangle`}</M> on the
           vertical axis and the everything-else direction{' '}
           <M>{String.raw`|\beta\rangle`}</M> on the horizontal, and the state is a single
-          arrow of length one.
+          arrow of length one. The horizontal direction is the normalized equal sum
+          of the N−1 unmarked basis states. Its coordinate is √(N−1) times one unmarked
+          amplitude; the vertical coordinate is the marked amplitude. Their squared
+          coordinates therefore sum to the total probability, one.
         </p>
         <p>
           The uniform superposition <M>{String.raw`|s\rangle`}</M> starts almost
@@ -32,8 +37,8 @@ export function TwoMirrors() {
           <M>{String.raw`|s\rangle`}</M> itself: a <strong>reflection across the{' '}
           <M>{String.raw`|s\rangle`}</M> line</strong>. And a reflection followed by a
           reflection is — try it — a <strong>rotation</strong>, by twice the angle between
-          the mirrors: <M>{String.raw`2\theta`}</M> per iteration, always toward the
-          marked axis.
+          the mirrors: <M>{String.raw`2\theta`}</M> per iteration, initially toward the
+          marked axis and then past it if we continue.
         </p>
       </Prose>
       <WidgetFrame

--- a/demos/grover/src/essay/WhySqrtN.tsx
+++ b/demos/grover/src/essay/WhySqrtN.tsx
@@ -41,7 +41,7 @@ export function WhySqrtN() {
       <Prose>
         <p>
           So a Grover run is not "iterate until found." It is: compute{' '}
-          <M>{String.raw`t^{*} = \operatorname{round}\!\left(\frac{\pi}{4\theta}-\frac12\right)`}</M> ahead of time for one known winner. For N = 8 this gives two iterations
+          <M>{String.raw`t^{*} = \operatorname{round}\!\left(\frac{\pi}{4\theta}-\frac12\right)`}</M> ahead of time when exactly one winner is known to exist. For N = 8 this gives two iterations
           and success probability 121/128. Take that many steps, then measure once and check the answer classically
           (one more oracle call; if you were unlucky, rerun). The payoff compounds
           brutally with scale:

--- a/demos/grover/src/essay/WhySqrtN.tsx
+++ b/demos/grover/src/essay/WhySqrtN.tsx
@@ -41,8 +41,8 @@ export function WhySqrtN() {
       <Prose>
         <p>
           So a Grover run is not "iterate until found." It is: compute{' '}
-          <M>{String.raw`t^{*} = \lfloor \tfrac{\pi}{4}\sqrt N \rfloor`}</M> ahead of time,
-          take exactly that many steps, then measure once and check the answer classically
+          <M>{String.raw`t^{*} = \operatorname{round}\!\left(\frac{\pi}{4\theta}-\frac12\right)`}</M> ahead of time for one known winner. For N = 8 this gives two iterations
+          and success probability 121/128. Take that many steps, then measure once and check the answer classically
           (one more oracle call; if you were unlucky, rerun). The payoff compounds
           brutally with scale:
         </p>

--- a/src/content/blog/grovers-algorithm-is-two-mirrors.md
+++ b/src/content/blog/grovers-algorithm-is-two-mirrors.md
@@ -13,16 +13,18 @@ You are given $N$ shuffled boxes, one prize, and a yes/no check. Classically the
 
 "A quantum computer tries every answer at once" is the folklore, and it's uselessly half-true. A quantum state does assign an amplitude to every box simultaneously — but *measure* the uniform superposition and you get one box uniformly at random, exactly like guessing. Superposition alone buys nothing.
 
-The actual resource is that amplitudes are *signed*: two paths to the same outcome add before they're squared, so they can cancel. Grover's algorithm is nothing but choreographed interference — arranged so the wrong answers eat each other and the right one accumulates.
+In this construction the amplitudes remain real and can be *signed* (general quantum amplitudes are complex): two paths to the same outcome add before they're squared, so they can cancel. Grover's algorithm is nothing but choreographed interference — arranged so the wrong answers eat each other and the right one accumulates.
 
 ## Two mirrors
 
+An oracle is a circuit that checks a candidate. A reversible yes/no checker can be converted to a phase oracle; [IBM’s Grover tutorial](https://quantum.cloud.ibm.com/docs/en/tutorials/grovers-algorithm) shows that construction. The toy demo wires in a chosen winner to expose the mechanics. A useful search oracle tests a property without already knowing its solution.
+
 The choreography needs exactly two moves, both reflections:
 
-1. **The oracle** — the yes/no check, run in superposition — flips the *sign* of the marked box's amplitude. Nothing measurable changes: squaring erases a lone sign. The winner is branded invisibly.
+1. **The oracle** — the yes/no check, run in superposition — flips the *sign* of the marked box's amplitude. The box-label probabilities do not change yet: squaring erases the sign. The relative phase can affect later interference.
 2. **Diffusion** reflects every amplitude about the mean, $a_i \mapsto 2\bar a - a_i$. It knows nothing about which box is marked; it's pure democratic arithmetic. But the flipped bar has dragged the mean down, so the reflection throws that one bar high above the crowd while everyone else dips slightly.
 
-The essay animates that as bars — the mean line drawn, every bar passing through it. But the deeper picture is geometric. The whole state lives in a plane spanned by "the marked one" and "everything else," where the oracle is a reflection across one axis and diffusion is a reflection across the uniform state $|s\rangle$. And a reflection followed by a reflection is a **rotation** — by $2\theta$ per iteration, where
+The essay animates that as bars — the mean line drawn, every bar passing through it. But the deeper picture is geometric. The whole state lives in a plane spanned by "the marked one" and the normalized equal sum of the unmarked states. The horizontal coordinate is √(N−1) times a single unmarked amplitude, so the arrow has unit length. In this plane, the oracle is a reflection across one axis and diffusion is a reflection across the uniform state $|s\rangle$. And a reflection followed by a reflection is a **rotation** — by $2\theta$ per iteration, where
 
 $$
 \sin\theta = \frac{1}{\sqrt N}.
@@ -34,7 +36,7 @@ That one triangle is the entire algorithm. Success probability after $t$ steps i
 
 The essay ends the way I think every Grover explainer should:
 
-- The speedup is **quadratic, not exponential** — and provably optimal. Grover doesn't break encryption; it halves effective key bits, which is why the response was AES-256, not panic.
+- The speedup is **quadratic, not exponential** — and provably optimal. The square-root query scaling is not a practical runtime estimate for breaking encryption: constructing and running the checking circuit, including error correction, has substantial costs.
 - The algorithm is an **amplifier for whatever the oracle says**: mark the wrong box and it amplifies the wrong box to near-certainty. There's a sabotage bench where you can watch it do that.
 - The gate decomposition of diffusion actually implements $-(2|s\rangle\langle s|-I)$ — every amplitude comes out upside-down versus the textbook picture. No measurement can see a global phase, and the circuit widget shows the minus sign rather than hiding it.
 

--- a/src/content/projects/grover.ts
+++ b/src/content/projects/grover.ts
@@ -13,6 +13,8 @@ const project: ProjectMeta = {
 Grover's algorithm is the cleanest demonstration of how quantum computation actually
 works — not "trying every answer at once," but hiding an answer in a *sign* and then
 using interference to convert that hidden phase into probability you can measure. The
+real-amplitude version shown here can be drawn as signed bars; general quantum
+amplitudes are complex. For N candidate answers and one marked answer, the
 whole algorithm is two reflections: an oracle that flips the marked amplitude's sign,
 and a "diffusion" step that reflects every amplitude about the mean. Reflection ∘
 reflection = rotation, by exactly $2\\theta$ per step with $\\sin\\theta = 1/\\sqrt{N}$
@@ -27,12 +29,12 @@ engine:
 - **Rotation plane:** the state as one arrow between "the marked one" and "everything
   else," with both mirrors drawn — and a synced view proving bars and arrow are the
   same state.
-- **Circuit:** real gates (H, X, CCZ) on three qubits, stepped column by column, with
+- **Circuit:** a classical simulation of quantum gates (H, X, CCZ) on three qubits, stepped column by column, with
   a live norm readout and an honest footnote about the global phase the textbook
   decomposition introduces.
 
-Then the reader gets to break it: hand Grover an oracle that marks nothing (it spins
-forever) or the wrong box (it amplifies the wrong box to near-certainty — garbage in,
+Then the reader gets to break it: hand Grover an oracle that marks nothing (the uniform
+state stays fixed) or the wrong box (it amplifies the wrong box to near-certainty — garbage in,
 loud garbage out), and dial in $k$ marked items to find the $N{=}16,\\,k{=}4$ party
 trick where one iteration succeeds with certainty.
 


### PR DESCRIPTION
The local Grover essay presents real signed amplitudes as the general quantum state, calls a phase flip the only possible yes/no oracle action, and moves to a unit arrow without explaining the sqrt(N-1) normalization of unmarked states. The project says an oracle marking nothing spins forever, even though the state is fixed. Encryption claims overgeneralize query complexity.

Separates the simulator from quantum hardware and real bars from general complex amplitudes. Explains reversible checking, phase kickback and normalized rotation coordinates; corrects the empty oracle, integer stopping and cryptographic cost claims.

Validation: preserved simulator code; reviewed against the analytic probability and existing oracle/gate tests. Full demo build and tests run in CI.


Closes #43
