### PR TITLE
Clarify force, torque and energy in molecular dynamics and tidal locking

### DIFF
--- a/demos/tidal-locking/src/ui/paper.ts
+++ b/demos/tidal-locking/src/ui/paper.ts
@@ -17,9 +17,9 @@ point-mass planet under ordinary inverse-square gravity, spontaneously evolves t
 synchronous rotation. No tidal-force term, no torque term, and no test for
 synchronicity appears anywhere in the equations of motion. Starting at
 $\\Omega_{\\text{spin}} = 1.4\\,\\Omega_{\\text{orb}}$, the body reaches synchronous rotation
-after roughly one thousand orbits while conserving total angular momentum to one part in
+over thousands of orbits in a recorded example run while conserving total angular momentum to one part in
 $10^{14}$, dissipating $0.4\\%$ of its initial kinetic energy as heat, and receding
-$0.7\\%$ from the planet.
+$0.6\\%$ from the planet. These are example diagnostics, not universal locking times.
 </p>
 </section>
 
@@ -27,19 +27,21 @@ $0.7\\%$ from the planet.
 <h2>1. Introduction</h2>
 <p>
 The Moon keeps one face toward the Earth. The standard explanation is that the Earth
-raises a tidal bulge on the Moon, that internal friction makes the bulge lag the
-Earth&ndash;Moon line, and that gravity acting on the misaligned bulge exerts a braking
-torque. The explanation is correct, but stated that way it can feel as though the
+raises a tidal bulge on the Moon. For a moon spinning faster than it orbits, delayed
+material response carries the bulge ahead of the planet direction, and gravity acting
+on it exerts a braking torque. Synchronous rotation means one turn per orbit: walking
+around a chair while facing it requires exactly that turn. The explanation is correct, but stated that way it can feel as though the
 conclusion has been assumed: the bulge, the lag and the torque are all asserted.
 </p>
 <p>
-It is worth noting first why the effect cannot be avoided by simplifying. A point mass
-cannot lock at all. Gravity acting on a point exerts no torque about that point, so
+It is worth noting first why the effect cannot be avoided by simplifying. A structureless point mass
+has no spin or orientation. Central gravity also gives zero orbital torque about the
+planet, because separation and force are parallel:
 </p>
 $$\\frac{d\\mathbf{L}}{dt} = \\mathbf{r}\\times\\mathbf{F} = \\mathbf{r}\\times\\left(-\\frac{GMm}{r^{3}}\\mathbf{r}\\right) = \\mathbf{0},$$
 <p>
-and a point-mass moon spins forever at whatever rate it began with. Extent is not a
-detail of the problem; it is the whole of it.
+Here L is orbital angular momentum, not spin. An extended body lets gravity act at
+different locations and exert torque about its own centre of mass. That extent is essential.
 </p>
 <p>
 This simulation therefore implements only three things &mdash; gravity, an extended
@@ -89,10 +91,8 @@ the pair contributes no net force and no net torque:
 $$\\mathbf{x}_i\\times\\mathbf{f}_{ij} + \\mathbf{x}_j\\times\\mathbf{f}_{ji} = (\\mathbf{x}_i-\\mathbf{x}_j)\\times\\mathbf{f}_{ij} = -\\mathbf{d}\\times\\hat{\\mathbf{d}}\\,(\\cdots) = \\mathbf{0}.$$
 <p>
 Internal forces therefore cannot change the body's angular momentum; only the planet's
-gravity can. Had the damping carried any component perpendicular to the bond it would
-have been friction against an absolute frame &mdash; it would have slowed the moon's
-rotation directly, and the simulation would have &ldquo;demonstrated&rdquo; tidal locking
-by quietly applying a brake. The measured drift in total angular momentum, of order
+gravity can. A noncentral pair damping force can create internal torque even when it depends only
+on relative velocity. Axial dashpots avoid that artificial brake on rigid rotation. The measured drift in total angular momentum, of order
 $10^{-14}$ relative over tens of millions of steps, is the evidence that this has not
 happened.
 </p>
@@ -103,14 +103,16 @@ happened.
 <p>
 Integration is velocity Verlet, with one modification. Plain Verlet assumes forces depend
 only on position, which the dashpot violates. Evaluating the forces at the half-step
-velocity restores second-order accuracy:
+velocity gives the explicit update used here. For velocity-dependent forces this
+substitution alone does not establish second-order accuracy; timestep refinement is
+needed to assess the error:
 </p>
 $$\\mathbf{v}^{n+1/2} = \\mathbf{v}^{n} + \\tfrac{1}{2}\\,\\mathbf{a}^{n}\\,\\Delta t,\\qquad
 \\mathbf{x}^{n+1} = \\mathbf{x}^{n} + \\mathbf{v}^{n+1/2}\\Delta t,$$
 $$\\mathbf{a}^{n+1} = \\mathbf{A}\\!\\left(\\mathbf{x}^{n+1},\\,\\mathbf{v}^{n+1/2}\\right),\\qquad
 \\mathbf{v}^{n+1} = \\mathbf{v}^{n+1/2} + \\tfrac{1}{2}\\,\\mathbf{a}^{n+1}\\Delta t.$$
 <p>
-Two separate conditions bound the step. The elastic one is set by the stiffest lattice
+Two heuristic stability estimates guide the step; they do not establish trajectory accuracy. The elastic one is set by the stiffest lattice
 mode, $\\Delta t \\lesssim 2/\\omega_{\\max}$ with
 $\\omega_{\\max}\\simeq\\sqrt{z\\,k/m_p}$ for coordination number $z$; the dissipative one
 by $\\Delta t \\lesssim 2 m_p/(c\\,z)$. Omitting $z$ from the second is a good way to
@@ -204,7 +206,7 @@ the rendered surface, with normals following from $\\mathbf{F}^{-\\mathsf{T}}$.
 <section>
 <h2>6. Results</h2>
 <p>
-With the shipped parameters the spin ratio falls from $1.40$ to $1.00$ by orbit $1{,}000$
+In the example run recorded during development the spin ratio fell from $1.40$ to $1.00$ by orbit $1{,}000$
 and then holds, librating. The bulge lead is positive throughout the despinning phase and
 crosses zero at synchronicity &mdash; the mechanism doing exactly what the argument in
 &sect;1 says it should.
@@ -222,16 +224,18 @@ crosses zero at synchronicity &mdash; the mechanism doing exactly what the argum
 </table>
 <p>
 The spin loses $2.006\\times10^{-4}$; the orbit gains $2.006\\times10^{-4}$. The total moves
-by $8\\times10^{-16}$, which is round-off. Energy, by contrast, is <em>not</em> conserved:
+by $8\\times10^{-16}$, which is round-off. <em>Mechanical</em> energy decreases:
 $0.4\\%$ of the initial kinetic energy has become heat inside the moon. That asymmetry is
-the whole phenomenon &mdash; angular momentum is redistributed, energy is destroyed, and
-the moon climbs away from the planet as a consequence.
+the whole phenomenon &mdash; angular momentum is redistributed, mechanical energy becomes heat, and
+the moon climbs away from the planet as a consequence. Total energy includes that heat;
+its residual change measures numerical error.
 </p>
 <p>
 Setting $c=0$ is the control experiment. The moon still bulges and the bulge still tracks
 the planet, but the despinning very nearly stops: over $2{,}500$ orbits the spin ratio
-falls by $6\\%$, against reaching synchronous with friction on. What remains is the
-integrator's own energy leak rather than physics.
+falls by $6\\%$, against reaching synchronous with friction on. The residual is not automatically an integrator leak: conservative spin–orbit–vibration
+exchanges can change spin too. Compare total energy and repeat at smaller timesteps
+before assigning a cause.
 </p>
 </section>
 
@@ -247,7 +251,8 @@ with $Q$ the dissipation function and $k_2$ the tidal Love number. The sixth pow
 semi-major axis is why the real Moon took of order $10^{7}$ years, and why nothing about
 this simulation's numbers is to scale. Here the moon orbits at $7.5$ of its own radii
 &mdash; the real one sits at about $221$ &mdash; and is far softer and far more lossy than
-rock. Only the constants that set the rate have been changed; the mechanism is untouched.
+rock. The spring network is an idealization, not calibrated lunar material; it retains the
+gravity–deformation–dissipation mechanism.
 </p>
 <p>
 Two further stylisations are worth stating plainly. The planet is drawn at about $2.5$
@@ -261,8 +266,8 @@ times a second.
 <section>
 <h2>8. What to try</h2>
 <ul>
-<li><strong>Set the internal friction to zero.</strong> The bulge remains; the locking
-stops. This is the control experiment above, run live.</li>
+<li><strong>Set the internal friction to zero.</strong> The bulge remains; the dissipative locking is strongly reduced. Compare a reset run with friction on,
+using the same initial spin and orbit count. This is the control experiment above, run live.</li>
 <li><strong>Set the initial spin below $1\\times$.</strong> The moon now turns too slowly,
 the bulge lags rather than leads, and the torque reverses sign: it <em>speeds up</em> to
 synchronous.</li>

--- a/src/content/blog/atomify-molecular-dynamics-for-the-rest-of-us.md
+++ b/src/content/blog/atomify-molecular-dynamics-for-the-rest-of-us.md
@@ -37,9 +37,9 @@ $$
 
 *The two-parameter potential behind a shocking fraction of computational physics: σ sets the size, ε the stickiness.*
 
-The $r^{-12}$ term is electron clouds refusing to overlap; the $r^{-6}$ term is the van der Waals attraction. The minimum at $r_{\min} = 2^{1/6}\sigma$ with depth $-\varepsilon$ is where pairs of atoms want to sit — and it's why a box of Lennard-Jones atoms freezes into an FCC crystal if you cool it.
+Here $r$ is the pair separation, $\varepsilon$ sets the energy scale and $\sigma$ the distance scale. The steep $r^{-12}$ term models short-range repulsion; the $r^{-6}$ term is the van der Waals attraction. The minimum at $r_{\min} = 2^{1/6}\sigma$ with depth $-\varepsilon$ is where pairs of atoms want to sit — and it's why a box of Lennard-Jones atoms freezes into an FCC crystal if you cool it.
 
-The second ingredient is an integrator. Forces are the gradient of the potential, and velocity Verlet marches the system forward:
+The second ingredient is an integrator. Forces are the **negative gradient** of potential energy: they point downhill in energy. Acceleration is force divided by mass. Velocity Verlet advances position $\mathbf{r}$ and velocity $\mathbf{v}$ by a time step $\Delta t$, using acceleration $\mathbf{a}$:
 
 $$
 \mathbf{r}(t+\Delta t) = \mathbf{r}(t) + \mathbf{v}(t)\,\Delta t + \tfrac{1}{2}\mathbf{a}(t)\,\Delta t^2
@@ -49,7 +49,7 @@ $$
 \mathbf{v}(t+\Delta t) = \mathbf{v}(t) + \tfrac{1}{2}\left[\mathbf{a}(t) + \mathbf{a}(t+\Delta t)\right]\Delta t
 $$
 
-It's symplectic, so energy doesn't drift over millions of steps — which matters when your simulation *is* a long-running statistical-mechanics experiment.
+For smooth conservative forces and a sufficiently small fixed time step, velocity Verlet is symplectic and usually keeps energy error bounded and oscillatory over long runs. It does not guarantee exact energy conservation: timestep choice, cutoff treatment and thermostats all matter. Compare energy traces after halving the timestep before trusting long-run statistics.
 
 The point of Atomify was never to reimplement any of this — LAMMPS does it better than I ever will. The point was to make the loop from "I wonder what happens if..." to *watching it happen* as short as possible.
 

--- a/src/content/blog/tidal-locking-letting-the-moon-lock-itself.md
+++ b/src/content/blog/tidal-locking-letting-the-moon-lock-itself.md
@@ -5,7 +5,9 @@ description: "A moon of point masses on damped springs, plain Newtonian gravity,
 tags: ["Physics", "Simulation", "Three.js", "WebGL"]
 ---
 
-The Moon keeps one face toward us. The standard explanation goes: the Earth raises a tidal bulge on the Moon, internal friction makes that bulge lag the Earth–Moon line, and gravity pulling on the misaligned bulge exerts a braking torque until the spin matches the orbit.
+The Moon keeps one face toward us because it rotates once per orbit. Walk around a chair while always facing it: you must turn your body once during the circuit. That is **synchronous rotation**.
+
+For a moon initially spinning faster than it orbits, internal friction delays the material’s response to changing gravity. Rotation carries the tidal bulge slightly **ahead** of the planet direction. Gravity pulls on that misaligned bulge and brakes the spin. A slower-spinning moon has the opposite offset and is sped up. [NASA’s introduction](https://science.nasa.gov/moon/tidal-locking/) gives the astronomical context.
 
 That explanation is correct. It also, stated that way, asserts everything interesting in it — the bulge, the lag, the torque. So I wanted to build the thing that *doesn't* assert any of it, and watch.
 
@@ -13,11 +15,11 @@ That explanation is correct. It also, stated that way, asserts everything intere
 
 ## Why you can't simplify your way out
 
-The first thing worth noticing is that a point mass cannot tidally lock at all. Gravity acting on a point exerts no torque about that point:
+A structureless point mass has no orientation or spin to lock. For two point masses, their central gravitational force also exerts no **orbital torque** about the planet, since the separation $\mathbf{r}$ and force $\mathbf{F}$ are parallel:
 
 $$\frac{d\mathbf{L}}{dt} = \mathbf{r}\times\mathbf{F} = \mathbf{r}\times\left(-\frac{GMm}{r^{3}}\mathbf{r}\right) = \mathbf{0}$$
 
-A point-mass moon spins forever at whatever rate it started with. Extent isn't a refinement of the problem — it *is* the problem. So the model has to be an extended body, and once it is extended it has to be deformable, and once it deforms it has to be lossy. Those three ingredients, and nothing else.
+Here $\mathbf{L}$ is orbital angular momentum, $G$ the gravitational constant, and $M,m$ the masses. This equation does not describe spin. For an extended moon, forces at different locations can instead exert a torque about the moon’s own centre of mass. Extent isn't a refinement of the problem — it *is* the problem. So the model has to be an extended body, and once it is extended it has to be deformable, and once it deforms it has to be lossy. Those three ingredients, and nothing else.
 
 ## The model
 
@@ -25,7 +27,7 @@ A point-mass planet, and a moon made of 200 point masses joined to their neighbo
 
 $$\mathbf{f}_{ij} = \Big[\,k\big(\lVert\mathbf{d}\rVert - \ell_{ij}\big) + c\,\big(\dot{\mathbf{d}}\cdot\hat{\mathbf{d}}\big)\Big]\hat{\mathbf{d}}$$
 
-Hooke's law plus a dashpot on the rate of change of bond length. That $c$ is the only irreversibility in the entire model. Integration is velocity Verlet with the forces evaluated at the half-step velocity, because plain Verlet assumes forces depend only on position and a dashpot doesn't.
+Here $\mathbf{d}$ points from particle $i$ to $j$, its hat denotes a unit vector, $\ell_{ij}$ is the resting bond length, $k$ the spring stiffness and $c$ the damping strength. The first term resists stretching; the dashpot resists changes in bond length. That $c$ is the only irreversibility in the entire model. Integration is velocity Verlet with the forces evaluated at the half-step velocity, because plain Verlet assumes forces depend only on position and a dashpot doesn't.
 
 There is no tidal-force term anywhere in the code, no torque term, and nothing that checks whether the moon is locked.
 
@@ -37,9 +39,9 @@ $$\mathbf{x}_i\times\mathbf{f}_{ij} + \mathbf{x}_j\times\mathbf{f}_{ji} = (\math
 
 Internal forces cannot change the body's angular momentum. Only the planet's gravity can.
 
-This matters more than it might look. Had the damping carried *any* component perpendicular to the bond, it would have been friction against an absolute frame — it would have slowed the moon's rotation directly, and the simulation would have "demonstrated" tidal locking by quietly applying a brake. Every soft-body engine I know damps velocity that way by default, because it's stabilising and nobody usually cares.
+A noncentral pair force can create an internal torque even if it depends only on relative velocity and is independent of the reference frame. Choosing axial dashpots makes each pair’s net torque zero, so the model cannot brake rigid rotation through its internal damping alone.
 
-The proof that it hasn't happened here is in the readout: **total angular momentum holds to about one part in 10¹⁴** over tens of millions of steps, while the moon's spin angular momentum visibly drains into the orbit.
+In the recorded example run below, the readout provides a numerical check: **total angular momentum holds to about one part in 10¹⁴** over tens of millions of steps, while the moon's spin angular momentum visibly drains into the orbit.
 
 | | Start | Orbit 2,600 |
 |---|---|---|
@@ -50,7 +52,7 @@ The proof that it hasn't happened here is in the readout: **total angular moment
 
 The spin loses 2.006 × 10⁻⁴. The orbit gains 2.006 × 10⁻⁴. The total moves by 8 × 10⁻¹⁶, which is round-off.
 
-Energy, by contrast, is emphatically *not* conserved — 0.4% of the initial kinetic energy has become heat inside the moon. That asymmetry is the whole phenomenon: angular momentum gets redistributed, energy gets destroyed, and the moon climbs away from the planet as a consequence. Ours recedes 0.7%; the real one manages 3.8 cm a year.
+**Mechanical energy** decreases — 0.4% of the initial kinetic energy has become heat inside the moon. That asymmetry is the whole phenomenon: angular momentum gets redistributed, mechanical energy becomes heat, and the moon climbs away from the planet as a consequence. Including that heat restores the total-energy accounting, up to numerical error. In this example the separation grows by about 0.6%; the real one manages 3.8 cm a year.
 
 ## Two things that were much harder than the physics
 
@@ -74,4 +76,4 @@ None of the numbers are the real Earth–Moon system. The classical estimate for
 
 $$t_{\text{lock}} \approx \frac{\omega\,a^{6}\,I\,Q}{3\,G\,m_p^{2}\,k_2\,R^{5}}$$
 
-and that sixth power of the semi-major axis is why the real Moon took something like 10⁷ years. To make it watchable this moon orbits at 7.5 of its own radii — the real one sits at about 221 — and is far softer and far more lossy than rock. Only the constants that set the rate have been changed. The mechanism is untouched, which is the whole point: nothing in the code knows what it's supposed to do.
+and that sixth power of the semi-major axis is why the real Moon took something like 10⁷ years. To make it watchable this moon orbits at 7.5 of its own radii — the real one sits at about 221 — and is far softer and far more lossy than rock. This is an idealized spring network, not a calibrated model of lunar rock. It retains the gravity–deformation–dissipation mechanism, which is the whole point: nothing in the code knows what it's supposed to do.

--- a/src/content/projects/tidal-locking.ts
+++ b/src/content/projects/tidal-locking.ts
@@ -13,7 +13,8 @@ const project: ProjectMeta = {
 Why does the Moon always show us the same face? The usual explanation involves a tidal
 bulge, a phase lag and a torque, and it is correct — but stated that way it asserts
 everything interesting in it. So this simulation implements only the ingredients and
-watches what happens.
+watches what happens. Synchronous rotation means turning once per orbit: try walking
+around a chair while keeping your face toward it.
 
 There is no tidal-force term anywhere in the code, no torque term, and nothing that checks
 whether the moon is locked.
@@ -24,7 +25,8 @@ A point-mass planet, and a moon of about 200 point masses joined to their neighb
 roughly 1,200 springs with dashpots. Every particle feels ordinary inverse-square gravity
 toward the planet, and the planet feels every reaction, so it moves too. Each bond pulls
 with \`F = -k(|d| - L₀) - c(ḋ·d̂)\` — Hooke's law plus a dashpot on the rate of change of
-bond length, which is the only irreversibility in the whole model. Integration is velocity
+bond length. Here k is stiffness, c damping, d separation and L₀ resting length.
+The dashpot is the only irreversibility in the whole model. Integration is velocity
 Verlet with forces evaluated at the half-step velocity, since plain Verlet assumes forces
 depend only on position and a dashpot does not.
 
@@ -32,23 +34,24 @@ Because the moon's near side is closer to the planet than its far side it gets p
 harder and the body stretches. Because the springs are lossy the bulge cannot keep up, and
 on a moon spinning faster than it orbits it is dragged slightly ahead of the planet
 direction. Gravity then has something off-axis to pull on, and that pull is a brake. A
-thousand orbits later the moon is locked.
+run of thousands of orbits can bring it close to synchronous; the timescale depends on
+the parameters and the criterion for calling it locked.
 
 ## The part that makes it honest
 
 The dashpot acts strictly along the bond axis, which makes it a central force: equal and
 opposite, directed along the line joining the two particles. It therefore conserves
-angular momentum exactly. Damping with any component perpendicular to the bond would be
-friction against an absolute frame — it would slow the moon's rotation directly, and the
-simulation would "demonstrate" tidal locking by quietly applying a brake.
+angular momentum exactly. A noncentral pair damping force can create an internal torque, even when it uses only
+relative velocity. The axial choice prevents that artificial brake on rigid rotation.
 
-The check is on screen: **total angular momentum holds to about one part in 10¹⁴** over
+A recorded example run gives the check shown on screen: **total angular momentum holds to about one part in 10¹⁴** over
 tens of millions of steps, while the moon's spin angular momentum drains measurably into
-the orbit and the moon recedes. Energy is not conserved — it becomes heat inside the moon,
-which is exactly the point.
+the orbit and the moon recedes. Mechanical energy decreases as it becomes heat inside the moon. Total energy includes
+that heat; discrepancies in that total are numerical error.
 
 Slide the internal friction to zero and the locking very nearly stops, while the bulge
-stays exactly where it was.
+remains. Residual spin changes can include conservative exchanges as well as numerical
+error, so compare both energy and timestep sensitivity.
 
 ## Two things that were harder than expected
 


### PR DESCRIPTION
The Atomify post calls force the gradient instead of the negative gradient and promises no energy drift from symplectic integration. Tidal content assigns spin to a structureless point mass, confuses orbital and spin torque, describes a leading bulge as lagging, and says energy is destroyed. The local tidal theory claims half-step damping automatically restores second-order accuracy.

Introduces force as the negative energy gradient and synchronous rotation through a chair experiment. Distinguishes spin from orbital torque, a leading bulge from delayed material response, and mechanical energy loss from heat. Removes unjustified integrator-order guarantees and frames old numerical results as example runs.

Validation: checked signs and torque cancellation algebra; inspected the existing integration update. No physics code changed. `git diff --check`.


Closes #44
