### PR TITLE
Build a beginner bridge into the FEM derivation and correct solver claims

### DIFF
--- a/demos/blast-wall/src/ui/paper.ts
+++ b/demos/blast-wall/src/ui/paper.ts
@@ -11,6 +11,13 @@ export const PAPER = `
 <p class="byline">On what this solver actually solves, the choices behind it, and what it leaves out.</p>
 
 <section>
+<h2>Before the equations</h2>
+<p>Imagine pushing the middle of a brick while holding its ends. The unknown is its displacement: how far each location moves. A mesh divides the brick into small elements, with nodes at their corners. Shape functions interpolate the motion between those nodes. Changes in displacement give strain (relative stretching and shearing); a material law converts strain to stress (internal force per area). Surface force per area is called traction. Mortar is the layer joining bricks; here its opening and sliding are represented by interface laws.</p>
+<p>The finite element method (FEM) balances these forces through weighted integrals. A virtual displacement is a small imagined motion, compatible with the supports, used as a weight. Requiring balance for each independent nodal motion gives equations for the nodal displacements. This is the bridge from a continuous brick to numbers a computer can advance.</p>
+<p>Read the equations below as a map of that process. A dot over displacement means a time derivative; two dots mean acceleration. Ω denotes a volume, Γ a surface, and an integral adds contributions over it. A colon between stress and strain tensors sums their matching components.</p>
+</section>
+
+<section>
   <h2>Abstract</h2>
   <p class="abstract">
     Every brick on screen is a mesh of hexahedral finite elements, and every mortar joint
@@ -57,7 +64,8 @@ export const PAPER = `
    = \\sum_b \\int_{\\Gamma_t} \\delta\\mathbf{u}\\cdot\\bar{\\mathbf{t}}\\,d\\Gamma
    + \\sum_b \\int_{\\Omega_b} \\rho\\,\\delta\\mathbf{u}\\cdot\\mathbf{b}\\,d\\Omega$$
   <p>
-    Four integrals — inertia, internal work, interface work, external work. Everything
+    Five integrals in four groups — inertia, internal work, interface work, and external work
+    from surface loading plus gravity. Everything
     below is a decision about how to evaluate one of them.
   </p>
 </section>
@@ -145,10 +153,10 @@ export const PAPER = `
   $$\\mathbf{F} = \\sum_{a=1}^{8}(\\mathbf{x}_a - \\bar{\\mathbf{x}}) \\otimes \\nabla_X N_a\\big|_{\\boldsymbol{\\xi}=0},
     \\qquad \\nabla_X N_a\\big|_{0} = \\left(\\frac{\\xi_a}{4a},\\ \\frac{\\eta_a}{4b},\\ \\frac{\\zeta_a}{4c}\\right),$$
   <p>
-    polar-decomposed as $\\mathbf{F} = \\mathbf{R}\\,\\mathbf{U}$, and the internal force
-    becomes
+    polar-decomposed as $\\mathbf{F} = \\mathbf{R}\\,\\mathbf{U}$, and the resisting internal force
+    (subtracted from external force in the update) becomes
   </p>
-  $$\\mathbf{f}^{\\,e}_{\\text{int}} = -\\,\\mathbf{R}\\,\\mathbf{K}_e\\Big(\\mathbf{R}^{\\mathsf{T}}(\\mathbf{x}_e - \\bar{\\mathbf{x}}) - (\\mathbf{X}_e - \\bar{\\mathbf{X}})\\Big),$$
+  $$\\mathbf{f}^{\\,e}_{\\text{int}} = \\mathbf{R}\\,\\mathbf{K}_e\\Big(\\mathbf{R}^{\\mathsf{T}}(\\mathbf{x}_e - \\bar{\\mathbf{x}}) - (\\mathbf{X}_e - \\bar{\\mathbf{X}})\\Big),$$
   <p>
     which is exactly zero for any rigid motion and reduces to linear elasticity when
     $\\mathbf{R} = \\mathbf{I}$. $\\mathbf{R}$ comes from Müller's iterative quaternion
@@ -252,9 +260,9 @@ export const PAPER = `
     \\qquad \\mathbf{u}^{\\,n+1} = \\mathbf{u}^{\\,n} + \\Delta t\\,\\mathbf{v}^{\\,n+1/2}$$
   <p>
     Because $\\mathbf{M}$ is diagonal there is no solve anywhere in the loop — and, more
-    importantly here, the scheme keeps running when elements lose all their stiffness. That
-    is why blast and crash codes are explicit: an implicit solver needs a tangent stiffness
-    that stays invertible, and a wall coming apart does not oblige. The scheme is
+    importantly here, the scheme keeps running when elements lose all their stiffness. Explicit methods avoid repeated nonlinear equilibrium solves as joints fail.
+    Implicit dynamics can include mass and damping in its effective matrix even when
+    material stiffness is singular; convergence and cost are the tradeoff. The scheme is
     conditionally stable at $\\Delta t \\le 2/\\omega_{\\max}$, and $\\omega_{\\max}$ is
     measured rather than guessed — power iteration on $\\mathbf{M}^{-1}\\mathbf{K}_e$ for
     the element, then compared against the joint springs at
@@ -322,4 +330,7 @@ export const PAPER = `
     predict something it could have got wrong has not been tested, only run.
   </p>
 </section>
+<p>These are software verification checks, not validation against a real blast test.
+Material calibration, mesh and timestep convergence, and physical measurements are
+needed before treating a predicted failure load as an engineering result.</p>
 `;

--- a/demos/blast-wall/src/ui/sheet.ts
+++ b/demos/blast-wall/src/ui/sheet.ts
@@ -24,7 +24,7 @@ const GUIDE = /* html */ `
   </li>
   <li>
     <b>Everything happens in 300 milliseconds</b>, so playback starts at 0.03× and goes
-    down to 0.003×. At real speed you would miss the entire event between two frames.
+    down to 0.003×. At 60 frames per second that is only about eighteen frames, too fast to inspect each crack.
   </li>
   <li>
     <b>Colour by joint damage</b> to see the crack path glowing through the mortar, or by
@@ -37,7 +37,7 @@ const GUIDE = /* html */ `
   </li>
   <li>
     <b>Every material number is a slider</b>, with its literature range behind it. Drive
-    the joint tensile strength to zero for a dry-stacked wall held up by friction alone.
+    both joint tensile strength and cohesion to zero for a dry-stacked wall held up by friction alone.
     Turn strain-rate hardening off and the same charge does more damage.
   </li>
   <li>

--- a/src/content/blog/a-brick-wall-from-the-weak-form-up.md
+++ b/src/content/blog/a-brick-wall-from-the-weak-form-up.md
@@ -11,6 +11,14 @@ It is the former, and the way to show that is not to say so but to write the cha
 
 **[Open the lab](/demos/blast-wall/)** if you want to watch while you read.
 
+## Before the equations
+
+Imagine pushing the middle of a brick while holding its ends. The unknown is its displacement: how far each location moves. A **mesh** divides the brick into small elements, with **nodes** at their corners. Shape functions interpolate the motion between those nodes. Changes in displacement give **strain** (relative stretching and shearing); a material law converts strain to **stress** (internal force per area). Surface force per area is called **traction**. Mortar is the layer joining bricks; here its opening and sliding are represented by interface laws.
+
+The finite element method (FEM) balances these forces through weighted integrals. A virtual displacement is a small imagined motion, compatible with the supports, used as a weight. Requiring balance for each independent nodal motion gives equations for the nodal displacements. This is the bridge from a continuous brick to numbers a computer can advance.
+
+Read the equations below as a map of that process. A dot over displacement means a time derivative; two dots mean acceleration. Ω denotes a volume, Γ a surface, and an integral adds contributions over it. A colon between stress and strain tensors sums their matching components.
+
 ## What is actually being solved
 
 Each brick is a continuum body $\Omega_b$ obeying momentum balance:
@@ -44,7 +52,7 @@ $$
 \;+\; \sum_b \int_{\Omega_b} \rho\,\delta\mathbf{u}\cdot\mathbf{b}\,d\Omega
 $$
 
-Four integrals: inertia, internal work, interface work, external work. Everything below is a decision about how to evaluate one of them.
+Five integrals in four groups: inertia, internal work, interface work, and external work from surface loading plus gravity. Everything below is a decision about how to evaluate one of them.
 
 ## Choosing the element
 
@@ -89,6 +97,8 @@ $$
 \lambda = \frac{E\nu}{(1+\nu)(1-2\nu)}, \qquad \mu = \frac{E}{2(1+\nu)}
 $$
 
+Here $E$ is Young’s modulus, measuring tensile stiffness, and $\nu$ is Poisson’s ratio, relating lateral contraction to axial extension. The constants $\lambda$ and $\mu$ parameterize the same isotropic elastic law.
+
 The consistent mass matrix would be $\mathbf{M}_e = \int_{\Omega_e}\rho\,\mathbf{N}^{\mathsf{T}}\mathbf{N}\,d\Omega$. It is row-summed to a diagonal instead, which for H8 gives exactly
 
 $$
@@ -111,10 +121,10 @@ $$
 \nabla_X N_a\big|_{\boldsymbol{\xi}=0} = \left(\frac{\xi_a}{4a},\ \frac{\eta_a}{4b},\ \frac{\zeta_a}{4c}\right)
 $$
 
-Polar-decompose $\mathbf{F} = \mathbf{R}\,\mathbf{U}$ and keep $\mathbf{R}$. The internal force becomes
+Polar-decompose $\mathbf{F} = \mathbf{R}\,\mathbf{U}$ and keep $\mathbf{R}$. Using the resisting-force convention (subtracted from external force in the acceleration update), the internal force becomes
 
 $$
-\mathbf{f}^{\,e}_{\text{int}} = -\,\mathbf{R}\,\mathbf{K}_e\Big(\mathbf{R}^{\mathsf{T}}(\mathbf{x}_e - \bar{\mathbf{x}}) - (\mathbf{X}_e - \bar{\mathbf{X}})\Big)
+\mathbf{f}^{\,e}_{\text{int}} = \mathbf{R}\,\mathbf{K}_e\Big(\mathbf{R}^{\mathsf{T}}(\mathbf{x}_e - \bar{\mathbf{x}}) - (\mathbf{X}_e - \bar{\mathbf{X}})\Big)
 $$
 
 which is exactly zero for any rigid motion and reduces to linear elasticity when $\mathbf{R} = \mathbf{I}$.
@@ -208,7 +218,7 @@ $$
 \mathbf{u}^{\,n+1} = \mathbf{u}^{\,n} + \Delta t\;\mathbf{v}^{\,n+1/2}
 $$
 
-Because $\mathbf{M}$ is diagonal there is no solve anywhere in the loop — and, more importantly for this problem, the scheme keeps running when elements lose all their stiffness. That is the reason blast and crash codes are explicit: an implicit solver needs a tangent stiffness matrix that stays invertible, and a wall coming apart does not oblige.
+Because $\mathbf{M}$ is diagonal there is no solve anywhere in the loop — and, more importantly for this problem, the scheme keeps running when elements lose all their stiffness. Explicit methods are common for short, violent events because they avoid costly nonlinear equilibrium solves as joints fail. Implicit dynamics can also handle lost stiffness: its effective system includes mass and damping as well as tangent stiffness. Convergence and cost are the tradeoff, not a requirement that material stiffness alone remain invertible.
 
 The scheme is conditionally stable:
 
@@ -224,7 +234,7 @@ $$
 
 — the time a dilatational wave takes to cross the smallest element — is the same statement, but it is only approximate for a hexahedron, and *which* mechanism governs changes the moment somebody drags the joint-stiffness slider. Getting this wrong does not degrade gracefully; it detonates.
 
-A small mass-proportional damping term $-\alpha\mathbf{M}\mathbf{v}$ uses the half-step velocity, which formally drops that term to first-order accuracy. It is standard practice in explicit codes and the damping is deliberately small — it exists to kill the highest-frequency ringing that lumping the mass introduces, not to model anything.
+A small mass-proportional damping term $-\alpha\mathbf{M}\mathbf{v}$ uses the half-step velocity, which formally drops that term to first-order accuracy. It is standard practice in explicit codes and the damping is deliberately small — it is numerical damping, not a calibrated material law. Its modal damping ratio is $\alpha/(2\omega)$, so it damps low-frequency modes more strongly in relative terms; it is not a selective high-frequency filter.
 
 ## The load
 
@@ -267,3 +277,5 @@ Every one of those claims is only worth as much as the checking behind it, so th
 The first of those is worth dwelling on, because the metric had to be replaced. The obvious measure — how many separate pieces the wall falls into — turned out not to discriminate at all: both bonds shed a couple of stragglers and land on the same number. What the bond decides is not how *much* cracks but *where*, and a test that had been quietly passing on a proxy is not the same as a test that passes on the claim.
 
 That last pair is the point. A simulation that has not been asked to predict something it could have got wrong has not been tested, only run.
+
+These checks verify implementation and controlled numerical behavior. They do not validate a particular real wall under a real blast. That would also require measured material properties, mesh and timestep convergence, and comparison with physical experiments.

--- a/src/content/projects/blast-wall.ts
+++ b/src/content/projects/blast-wall.ts
@@ -31,11 +31,10 @@ bottom, and what is left of the structure stands there.
 ## The thing worth seeing
 
 Switch the bond from **løperforband** — the half-brick offset every mason uses — to stack
-bond, where the head joints line up, and fire the same charge. The running-bonded wall
-holds together in a handful of large pieces: a crack has to staircase down through a bed
-joint, along a head joint, and work its way around every brick in its path. The
-stack-bonded wall unzips. Continuous vertical cracks run the full height of it and the
-wall falls into columns. Nothing in the code knows this is supposed to happen — the crack
+bond, where the head joints line up, and fire the same charge. Compare the damage pattern rather than just counting fragments.
+Running bond interrupts aligned vertical joints, so cracks must change direction or
+find another route. Stack bond provides continuous vertical paths; in the tested
+comparison, a larger fraction of its head joints crack. Nothing in the code knows this is supposed to happen — the crack
 path is wherever joints exceeded their strength. It is simply the reason the bond pattern
 exists, made visible.
 
@@ -99,7 +98,7 @@ whose area under the curve is the fracture energy by construction, and the stabi
 of the time integrator — it is in
 [A brick wall, from the weak form up](/blog/a-brick-wall-from-the-weak-form-up). That post
 also carries the honest list of what this is *not*: explicit only, corotational linear
-rather than large-strain, an interface integrated nodally rather than by quadrature, and
+rather than large-strain, an interface using nodal rather than interior Gauss quadrature, and
 bricks that cannot themselves break.
 
 ## Under the hood

--- a/src/content/projects/blast-wall.ts
+++ b/src/content/projects/blast-wall.ts
@@ -4,7 +4,7 @@ const project: ProjectMeta = {
   slug: 'blast-wall',
   title: 'Blast Wall Lab',
   description:
-    'A 3D finite element simulation of masonry hit by a blast wave: four brick walls bonded at the corners, every mortar joint cracking, sliding, bearing and crushing for real.',
+    'A 3D finite element simulation of masonry hit by a blast wave: four brick walls bonded at the corners, every mortar joint cracking, sliding, bearing and crushing through constitutive laws.',
   tags: ['TypeScript', 'WebGPU', 'Physics', 'Simulation', 'Finite Elements', 'Masonry'],
   liveUrl: '/demos/blast-wall/',
   repoUrl: 'https://github.com/andeplane/andeplane.github.io/tree/main/demos/blast-wall',
@@ -18,6 +18,10 @@ cohesive-frictional law, and a blast pulse whose peak pressure, duration and arr
 come from the charge mass and the standoff. Twenty-eight thousand elements and forty-six
 thousand joint node pairs, stepped on your GPU, in slow motion down to a thousandth of
 real time.
+
+Finite elements divide each brick into small boxes. Corner nodes carry displacement;
+interpolation fills in the motion between them. A material law turns deformation into
+forces, while separate joint laws decide when mortar opens, slides or crushes.
 
 The corners are the reason it is four walls and not one. A lone wall simply falls over,
 which is dramatic and says almost nothing. Tie it into return walls and you get the
@@ -49,7 +53,7 @@ fuger, or by speed to see what is actually flying.
 
 Every material number is a slider with its literature range behind it: the joint's tensile
 strength and cohesion, its friction coefficient, its fracture energy, its crushing
-strength, its stiffness, the brick's modulus and density. Drive the tensile strength to
+strength, its stiffness, the brick's modulus and density. Drive both tensile strength and cohesion to
 zero and you have a dry-stacked wall held up by nothing but friction and its own weight,
 which behaves completely differently. Turn strain-rate hardening off and watch the same
 charge do more damage, because masonry really is stronger when you load it fast.
@@ -71,7 +75,7 @@ its thrust onto a sliver of joint at each hinge, multiplying the stress by an or
 magnitude. Without the cap, such a wall turned out to be literally unbreakable. It just
 rang.
 
-## Why four walls cost nothing
+## Why four walls reuse the same mesh construction
 
 A room is not a special case anywhere in the solver, the mesher or the renderer. It falls
 out of one fact about masonry: the module. Two brick widths plus a joint make one brick
@@ -80,7 +84,7 @@ stretcher. Divide the stretcher into *n* lattice steps and the header into *n*/2
 lattice spacing comes out identical along the wall and through it. With a square plan
 lattice, a wall running the other way is just a brick elongated the other way: same
 lattice, same element, and the joint where a return wall meets a façade matches node for
-node like every other joint in the model. The mesher needed no changes at all.
+node like every other joint in the model. The same meshing rule applies. More walls still cost more elements, memory and computation.
 
 The corner itself alternates course by course — the walls one way run through the corner
 square, the walls the other way stop short, then they swap. That is how a mason turns a
@@ -101,8 +105,8 @@ bricks that cannot themselves break.
 ## Under the hood
 
 Explicit central-difference integration on a lumped mass — no linear solve, and it keeps
-running after elements lose all their stiffness, which is the entire reason blast codes are
-explicit. The elements are corotational, with the rotation pulled out of the deformation
+running after elements lose all their stiffness, which is useful for short fracture events. Implicit dynamics is also possible but
+requires effective-system solves and nonlinear convergence. The elements are corotational, with the rotation pulled out of the deformation
 gradient by an iterative polar decomposition warm-started from the previous step, so a
 brick tumbling through the air stays a brick instead of stretching into nonsense. The
 critical time step is measured by power iteration rather than estimated, and compared
@@ -122,8 +126,9 @@ rigid-body modes and its exact elastic response, that pulling a joint apart peak
 dissipates Gf, that a **simulated triplet shear test** recovers the cohesion and friction
 angle it was given from the fitted failure envelope, that linear momentum is conserved to a
 part in a million, that the measured critical time step really is critical — and, because
-it is the whole claim of the demo, that the same charge really does break a stack-bonded
-wall into more pieces than a running-bonded one.
+it is the whole claim of the demo, that the same charge damages a larger fraction of head joints in a stack-bonded
+wall than in a running-bonded one. Fragment count did not distinguish the tested cases.
+These checks establish controlled numerical behavior, not validation of real blast damage.
   `.trim(),
 }
 

--- a/src/content/projects/fem-lab.ts
+++ b/src/content/projects/fem-lab.ts
@@ -12,10 +12,12 @@ const project: ProjectMeta = {
   longDescription: `
 Draw a part, give it a material, hold it somewhere, push on it, and read off where it
 bends and how much. That is what a finite element program does, and this is one that
-opens as a web page. The engine is Rust compiled to WebAssembly; the linear solves run
+opens as a web page. Finite elements divide the part into small connected pieces;
+their shared nodes carry displacement or temperature, and interpolation fills in the
+space between nodes. Refining this mesh lets you check whether the result is converging. The engine is Rust compiled to WebAssembly; the linear solves run
 either through a sparse Cholesky factorisation on the CPU or as a conjugate gradient on
-your GPU through WebGPU, with the answer refined in double precision either way. Nothing
-is uploaded. The same engine also builds natively for the command line, and a Journal
+your GPU through WebGPU, with the answer refined in double precision either way. The numerical solver runs locally. The optional AI assistant is a separate service
+interaction, so local computation alone is not a blanket claim about all data flows. The same engine also builds natively for the command line, and a Journal
 replayed on your laptop and in the browser hashes to the same bytes.
 
 ## Every action is a command


### PR DESCRIPTION
The blast-wall post and demo jump directly into weak-form notation without explaining nodes, shape functions, stress or virtual displacement. They say implicit dynamics requires invertible material stiffness, use opposite internal-force signs in different equations, count five written integrals as four, and claim mass-proportional damping targets high frequencies. The project still says fragment count is the bond-pattern validation, contradicted by the post's explicit correction to head-joint damage.

Adds a physical-to-mathematical entry before the weak form and uses a consistent resisting-force sign. Corrects integral counts, implicit-solver and damping claims, dry-stack parameters, timing, and the bond-pattern test metric. Distinguishes software verification from physical validation.

Validation: checked equations against the subsequent central-difference update and existing head-joint assertions; `git diff --check`. Solver behavior is unchanged.


Closes #45
