### PR TITLE
Give project introductions concrete concepts and bounded claims

### DIFF
--- a/src/content/blog/ai-data-analytics-no-server-no-api-keys.md
+++ b/src/content/blog/ai-data-analytics-no-server-no-api-keys.md
@@ -17,15 +17,17 @@ Stack them and you get something that felt faintly illegal the first time it wor
 
 ![The whole analytics stack, inside one browser tab](/blog/ai-data-analytics/architecture.svg)
 
-*The network is used exactly once: to download model weights and the Python runtime. After that you can go offline.*
+*The app, model weights, Python runtime and required packages must first download and remain cached. The intended analysis loop can then run locally; offline availability depends on those assets being present.*
 
 ## Why code generation is the right architecture
 
 There's a tempting shortcut: hand the data itself to the LLM and let it answer directly. It's a trap. Models are unreliable at arithmetic over long contexts, your data may not even fit, and you can't audit vibes.
 
-Generating *code* fixes all three at once. The model only sees the schema and a few sample rows — tiny context, no matter how big the file. The arithmetic is done by pandas, which does not hallucinate a groupby. And every answer ships with its own receipt: the code is right there, and a suspicious user can read it.
+Generating *code* addresses context size and makes arithmetic inspectable. The model only sees the schema and a few sample rows — tiny context, no matter how big the file. Pandas executes the requested operations, but the generated operations can still be wrong. And every answer ships with its own receipt: the code is right there, and a suspicious user can read it.
 
-The loop that makes it actually usable is the retry loop. Generated code fails sometimes — a misspelt column, a type error on a date column. The error message goes straight back to the model for another attempt, entirely client-side. An 8B model with an error-feedback loop lands correct analyses far more often than its raw first-shot rate suggests — asking again is nearly free when there's no API meter running.
+For “return rate,” check whether the denominator is units sold, orders, or customers; a perfectly runnable calculation can silently use the wrong one. Inspect missing values, filters and units, then reproduce a small group by hand.
+
+The loop that makes it actually usable is the retry loop. Generated code fails sometimes — a misspelt column, a type error on a date column. The error message goes straight back to the model for another attempt, entirely client-side. An 8B model with an error-feedback loop can recover from execution failures, although semantic mistakes still need checking — asking again is nearly free when there's no API meter running.
 
 Follow-up questions keep the conversation context, so *"now only for 2024"* composes on top of the previous analysis. Charts come back as images rendered from the generated matplotlib figure, tables are sortable, and multiple files can be loaded and joined.
 
@@ -37,7 +39,7 @@ Follow-up questions keep the conversation context, so *"now only for 2024"* comp
 
 ## Why bother?
 
-Privacy, mostly — and distribution. There is an entire class of tabular data that people rightly refuse to upload: patient lists, payroll, customer exports, anything under NDA. Here the property isn't a promise in a privacy policy, it's an architectural fact: **your data never leaves the device**, and you can verify it with the network tab open.
+Privacy, mostly — and distribution. There is an entire class of tabular data that people rightly refuse to upload: patient lists, payroll, customer exports, anything under NDA. The intended architecture keeps inference and analysis local. Inspecting network activity can check data flow during a session; local execution alone does not establish the security of every dependency or guarantee future app behavior.
 
 And because it's just static files, sharing the entire product is sending a URL. No account, no key provisioning, no per-token bill. Anyone with a decent laptop gets a private data analyst for free.
 

--- a/src/content/blog/curling-physics-why-stones-curl.md
+++ b/src/content/blog/curling-physics-why-stones-curl.md
@@ -9,13 +9,13 @@ Joachim and I built a [curling game](https://andeplane.github.io/curling-simulat
 
 ## Ice friction isn't a constant
 
-Start with a fact every curler knows in their hands: a stone doesn't decelerate uniformly. It glides serenely off the release and then dies quickly at the end. Constant-μ Coulomb friction can't do that; ice friction *rises as the stone slows*. The standard model for ice has
+Start with a fact every curler knows in their hands: a stone doesn't decelerate uniformly. It glides serenely off the release and then dies quickly at the end. Constant-μ Coulomb friction can't do that; ice friction *rises as the stone slows*. The phenomenological law used here is
 
 $$
 \mu(v) = \mu_0 \sqrt{\frac{v_0}{v}}
 $$
 
-The microscopic story: friction melts a nanometre-scale water film under the running band, and the film — which is what makes ice ice — is thinner at low speed, so slow stones grip more. Integrating $\dot{v} = -\mu(v)\,g$ with a realistic release (~2.2 m/s for a draw) gives the familiar profile: a 28-metre glide over ~22 seconds with the deceleration loaded into the finale.
+Here µ is the friction coefficient and v is sliding speed. Thin water films, surface roughness and contact history all enter microscopic explanations of ice friction; this fitted speed law does not establish which mechanism dominates a curling shot. Integrating $\dot{v} = -\mu(v)\,g$ with a realistic release (~2.2 m/s for a draw) gives the familiar profile: a 28-metre glide over ~22 seconds with the deceleration loaded into the finale.
 
 The curl follows the same script, and this is the signature the whole game hangs on: **most of the break happens in the last third of the shot**. Reading it is the core skill — and any simulator that gets it wrong feels immediately fake:
 
@@ -47,7 +47,7 @@ $$
 
 with $\hat{\mathbf{n}}$ perpendicular to the velocity, the sign set by the handle, and $\delta(v)$ growing as the stone slows — which is what measurements of real stones show. Calibrate $\mu_0$ against hog-to-tee travel times and $\delta_0,\ \delta_{\max}$ against the observed ~1 m of total curl, and you get the blue curve in the figure — plus emergent behaviour curlers recognise: heavy takeout weight runs nearly straight, dying draws hook hard at the end.
 
-**Sweeping** falls out of the same model: brushing warms the ice ahead of the stone, thickening the water film — effectively lowering $\mu$ locally. Hold Space while the stone runs and it travels farther *and* curls less, which is exactly the tactical trade-off real sweepers manage. Angular momentum gets its own decay equation (the band's friction torque bleeds off spin slowly), and **collisions** are impulse-based with restitution and tangential friction, so spin transfers between stones on contact — you can throw a proper tap-back with roll.
+**Sweeping** is represented by lowering $\mu$ locally. This is a simplified gameplay model of brushing’s effects on the ice. Hold Space while the stone runs and it travels farther *and* curls less, a useful gameplay trade-off; real sweeping can affect both distance and line in more complicated ways. Angular momentum gets its own decay equation (the band's friction torque bleeds off spin slowly), and **collisions** are impulse-based with restitution and tangential friction, so spin transfers between stones on contact — you can throw a proper tap-back with roll.
 
 ## The renderer sells the physics
 

--- a/src/content/blog/teslacode-coding-from-the-drivers-seat.md
+++ b/src/content/blog/teslacode-coding-from-the-drivers-seat.md
@@ -23,13 +23,13 @@ But it doesn't block images. And that asymmetry is the whole product:
 
 The Mac side captures the screen with `getDisplayMedia()`, draws each frame to an offscreen canvas, encodes JPEGs, and ships the raw bytes over a **WebRTC DataChannel**. The Tesla side is almost embarrassingly simple: receive bytes, blob them, swap the `src` of an `<img>`. Ten to twenty frames a second, with quality and rate adapting to the car's connection. It's a video codec's dumbest cousin — no inter-frame compression at all — and for reading terminal output it's *fine*, because a Claude Code session is mostly static text that changes in bursts.
 
-The server never sees a frame. A little Hono + WebSocket service brokers the SDP/ICE handshake and gets out of the way; frames flow peer-to-peer, or through a TURN relay when the car's network demands it (it demands it — in-car connectivity is NAT all the way down).
+The signalling service does not receive decoded screen frames. A little Hono + WebSocket service brokers the SDP/ICE handshake and gets out of the way; frames flow peer-to-peer, or through a TURN relay when the car's network demands it (depending on network conditions).
 
 ## Closing the loop: talking back
 
 Watching your agent is half the job; the other half is answering it. The Tesla viewer has mic and send controls that travel *backwards* — Tesla touchscreen → DataChannel → the share page on the Mac → a small local daemon (`npx teslacode.dev`) that synthesises the actual keystrokes into whatever app you're sharing. Combined with Claude Code's voice mode, the loop closes completely: the agent asks, I answer out loud from the driver's seat, work continues.
 
-Note what's *not* in that path: the server. Keystrokes are peer-to-peer too. Given that this thing is typing into a terminal on my Mac, "the relay infrastructure cannot inject input even in principle" felt like a design requirement, not a feature.
+Note what's *not* in that path: the server. Keystrokes are peer-to-peer too. TURN can relay encrypted traffic without becoming an authorized sender of commands. That transport property matters, but trusted client code, session pairing and daemon authorization still determine who can type into the Mac.
 
 ## The unglamorous 80%
 

--- a/src/content/blog/webgpu-md-two-million-atoms-in-a-browser-tab.md
+++ b/src/content/blog/webgpu-md-two-million-atoms-in-a-browser-tab.md
@@ -9,11 +9,11 @@ Ever since I ported [Atomify](#/blog/atomify-molecular-dynamics-for-the-rest-of-
 
 **WebGPU changes that.** It exposes actual compute pipelines — storage buffers, workgroups, atomics — through a browser API. So the obvious experiment: write a molecular dynamics engine where *every* step of the physics loop is a WGSL kernel, and see how many atoms a browser tab can honestly move. That became [webgpu-md](https://github.com/andeplane/webgpu-md).
 
-The answer up front: **1–2 million Lennard-Jones atoms at interactive framerates** on an ordinary laptop GPU, with a 4-million-atom mode if you're patient. Roughly 10–50× the same algorithm in JavaScript, depending on system size.
+Development runs reached **1–2 million Lennard-Jones particles at interactive display rates**, with a 4-million-particle mode available. Those figures are workload-dependent observations, not a portable benchmark: record GPU, density, cutoff and simulation steps per frame when comparing. Display frames per second and simulated time advanced per second measure different things.
 
 ## The only algorithm that matters here
 
-The force loop is where all the time goes. Evaluating the Lennard-Jones potential between all pairs is $N(N-1)/2$ distance checks — hopeless at a million atoms. But the potential is short-ranged: beyond a cutoff $r_c$ (conventionally $2.5\sigma$) the interaction is negligible and skipped.
+The force loop is where all the time goes. Evaluating the Lennard-Jones potential between all pairs is $N(N-1)/2$ distance checks — hopeless at a million atoms. But the potential is short-ranged: beyond a cutoff $r_c$ (conventionally $2.5\sigma$) the remaining interaction is truncated as a modelling approximation. Its effect depends on the observable and cutoff treatment.
 
 Enter the classic **cell list**. Divide the box into cells at least $r_c$ wide and bin atoms into them. Any atom's neighbours must then live in its own cell or the ones directly adjacent — a 3×3 block in 2D, 3×3×3 = **27 cells** in 3D:
 
@@ -60,3 +60,5 @@ There's a scaling benchmark built in — 4K to 4M atoms — plus adjustable temp
 Fifteen years ago this simulation was a cluster job. Ten years ago, a CUDA workstation. Five years ago, a native app on a good laptop. Today it's a URL: [andeplane.github.io/webgpu-md](https://andeplane.github.io/webgpu-md). Nothing to install, no drivers to match — the same tab that runs your email now integrates Newton's equations for two million atoms.
 
 The next obvious step is hooking kernels like these back into the full LAMMPS-in-the-browser stack, so the interactive engine and the serious engine stop being different things.
+
+The near-linear neighbor-list cost also assumes bounded density and occupancy; putting many particles in one cell defeats that scaling. Lennard-Jones reduced units use the pair energy scale ε, length scale σ and particle mass to define simulation units.

--- a/src/content/projects/ai-data-analytics.ts
+++ b/src/content/projects/ai-data-analytics.ts
@@ -21,9 +21,17 @@ Upload any CSV or JSON file and describe what you want to know — "show me mont
 4. **Automatic visualisation** — generated charts are converted to images and rendered alongside sortable tables
 5. **Iterative refinement** — follow-up questions maintain conversation context so the model can build on previous analyses
 
+## Reading an answer critically
+
+A runnable program can answer the wrong question. For “highest return rate,” check
+that the denominator is items sold, not all returned items, and inspect how missing
+values and date filters are handled. Compare one small group by hand. Generated code
+makes an answer inspectable; successful execution alone does not make it correct.
+
 ## Design goals
 
-The goal was zero-dependency, privacy-first data exploration — no Python environment, no Jupyter, no server, no API keys. Everything runs in the browser and your data never leaves your device, making it easy to share a URL and let anyone analyse their own data without setup.
+The goal was zero-dependency, privacy-first data exploration — no Python environment, no Jupyter, no server, no API keys. The intended analysis path keeps model inference and data processing on the device, making it easy to share a URL and let anyone analyse their own data without a local Python setup. Browser runtimes, packages and model weights still
+need downloading and caching; local execution is not a blanket security guarantee.
   `.trim(),
 }
 

--- a/src/content/projects/calc-gpt.ts
+++ b/src/content/projects/calc-gpt.ts
@@ -19,8 +19,12 @@ and a plus sign.
 The blog post trains a two-layer GPT with about 27,000 parameters **live in your browser
 tab**: embeddings, causal self-attention, the backward pass, and Adam, all written from
 scratch in TypeScript on \`Float32Array\`s. No ML library, no autograd, no server. You watch
-the loss fall from ln(16) — uniform guessing — as the model discovers digits, then place
-value, then carrying, and you can query the live weights mid-training.
+the loss fall from ln(16), the next-character prediction loss for uniform guessing
+over sixteen tokens. A token is one character here; embeddings turn tokens into learned
+vectors, and causal self-attention combines earlier positions when predicting the next.
+Better accuracy on held-out sums is evidence of learned arithmetic behavior, but a
+falling loss alone does not reveal whether the model learned a carrying algorithm.
+You can query the live weights mid-training.
 
 ## The curriculum trick
 
@@ -36,8 +40,8 @@ recovers, while a subtraction curve climbs from zero — including negative answ
 The engine is dependency-injected throughout — RNG, data generators, optimizer, metrics
 sink, even the model behind an interface — and carries a 100% test-coverage gate in CI
 (statements, branches, functions, lines). The centerpiece test perturbs every parameter
-tensor and compares numerical gradients against the hand-derived backward pass, so if any
-equation in the post were coded wrong, CI would go red. A line-for-line numpy twin ships in
+tensor and compares numerical gradients against the hand-derived backward pass, to check the derivatives on tested inputs. Coverage and gradient checks help find
+implementation mistakes; they do not prove every equation or unseen answer correct. A line-for-line numpy twin ships in
 the repo for Python readers.
   `.trim(),
 }

--- a/src/content/projects/curling-simulator.ts
+++ b/src/content/projects/curling-simulator.ts
@@ -3,24 +3,24 @@ import type { ProjectMeta } from '@/types'
 const project: ProjectMeta = {
   slug: 'curling-simulator',
   title: 'Curling Simulator',
-  description: 'Physics-accurate browser curling game with 3D ice, realistic curl, and full WCF rules.',
+  description: 'Browser curling game with 3D ice, a phenomenological curl model, and match scoring.',
   tags: ['TypeScript', 'Three.js', 'Physics', 'Game'],
   liveUrl: 'https://andeplane.github.io/curling-simulator/',
   repoUrl: 'https://github.com/andeplane/curling-simulator',
   screenshot: '/projects/curling-simulator/preview.png',
   longDescription: `
-A full-featured curling game that runs in the browser, built with Three.js and TypeScript. The physics model is calibrated to match real-world curling behaviour rather than being a simple approximation.
+A full-featured curling game that runs in the browser, built with Three.js and TypeScript. Its phenomenological physics model is tuned to reproduce recognizable shots: it models observed behavior without claiming to settle the microscopic cause of curl. In curling, players slide stones toward a circular target, the house; weight means how far a shot travels, and line means its path.
 
 ## Physics model
 
-- **Velocity-dependent friction** — µ ∝ v⁻¹/² so the stone slows more quickly at low speeds, just like on real ice
+- **Velocity-dependent friction** — µ ∝ v⁻¹/² so the stone slows more quickly at low speeds, in the chosen model (µ is the friction coefficient and v the speed)
 - **Lateral curl** — curl strengthens late in the trajectory (front-to-back asymmetry), matching how real stones behave due to pebble contact
-- **Angular spin decay** — rotational speed bleeds off correctly through the shot
+- **Angular spin decay** — rotational speed decays through the shot
 - **Impulse-based collisions** — restitution, tangential friction, and spin transfer between stones; positional correction prevents overlap
 
 ## Gameplay
 
-Full 10-end matches with alternating hammer, hog-line violation detection, and WCF scoring. Hold **Space** while a stone is moving to sweep — sweeping reduces friction and extends travel distance.
+Ten-end matches with hog-line violation detection and curling-style scoring. An end is one round of deliveries; the hammer is its last stone. The team closest to the center scores for stones closer than the opponent’s nearest stone. This is a game implementation, not a claim of complete tournament-rule coverage. Hold **Space** while a stone is moving to sweep — sweeping reduces friction and extends travel distance.
 
 A curved ghost line predicts the stone's trajectory before you throw, accounting for the current aim angle and speed.
 

--- a/src/content/projects/particle-defence.ts
+++ b/src/content/projects/particle-defence.ts
@@ -15,15 +15,15 @@ A competitive tower defence game where instead of placing turrets, you spawn par
 
 Each player controls a base on opposite sides of the map. Particles spawn at intervals and drift toward the enemy base — biased random motion with wall bounce — so maze walls physically herd them. Place obstacles to redirect enemy particles while leaving clean corridors for your own. Earn gold by killing enemy particles, spend it on upgrades.
 
-**Upgrade tree** — particles can be upgraded with higher speed, shields, or homing behaviour. Special abilities include area-of-effect blasts and a nuclear strike that clears a large section of the maze.
+**Upgrades** — health, attack, radius, spawn rate, speed, defense, maximum particles and interest on banked gold. Research Laser and Slow towers for damage and area control; the nuke clears enemy particles and towers on a cooldown.
 
 ## AI opponent
 
-The AI controller evaluates the maze topology to decide when to upgrade vs. when to rebuild routing. It uses a threat-score heuristic: if many of its particles are dying in the same map region, it reroutes them and considers a nuke. Difficulty scales by adjusting the AI's gold-spending rate and reaction time.
+The AI makes economic and timing decisions: which upgrade to buy, where to place researched towers, and when to use a nuke. It cannot reroute particles, because their motion uses the same local wall-bounce rule as yours. Difficulty changes its priorities and reaction speed.
 
 ## Architecture
 
-Built with **Phaser 3** for rendering and physics. All game constants live in a single \`config.ts\` file so balancing changes are easy. The post-game stats screen shows nine dual-series timeline graphs (gold, particles spawned, particles killed, etc.) rendered as canvas line charts with glow effects.
+Built with **Phaser 3** for rendering and physics. All game constants live in a single \`config.ts\` file so balancing changes are easy. The post-game stats screen shows ten dual-series timeline graphs (gold, particles spawned, particles killed, etc.) rendered as canvas line charts with glow effects.
   `.trim(),
 }
 

--- a/src/content/projects/special-relativity-travel.ts
+++ b/src/content/projects/special-relativity-travel.ts
@@ -9,7 +9,12 @@ const project: ProjectMeta = {
   repoUrl: 'https://github.com/andeplane/special-relativity-travel',
   screenshot: '/projects/special-relativity-travel/preview.png',
   longDescription: `
-A browser-based simulator that makes the effects of special relativity tangible. Configure a journey between Earth and any star or galaxy, set your ship's max speed (as a fraction of c) and acceleration in g's, and watch the physics update in real time.
+A browser-based simulator that makes the effects of special relativity tangible. Configure a journey between Earth and any star or galaxy, set your ship's max speed (as a fraction of c) and acceleration in g’s (multiples of Earth gravity), and watch the physics update in real time.
+
+Here c is the speed of light. Proper acceleration is what an accelerometer aboard
+the ship reads; it differs from acceleration measured in Earth’s frame as speed rises.
+The model assumes flat spacetime, neglecting gravity and cosmological expansion, so
+very distant galaxy trips are conceptual examples.
 
 ## Relativistic physics
 
@@ -17,7 +22,7 @@ All calculations use proper special-relativistic kinematics — no Newtonian app
 
 - **Lorentz factor** — γ = 1 / √(1 − v²/c²) drives all derived quantities
 - **Time dilation** — journey time as experienced on the ship vs. clocks back on Earth, integrated across the full acceleration/coast/deceleration profile
-- **Length contraction** — the universe shrinks along the direction of travel; the 3D scene shows both the rest-frame distance and the contracted distance side by side
+- **Length contraction** — distances along travel measured simultaneously in the ship’s instantaneous inertial frame are shorter than in the Earth–target rest frame; the 3D scene shows both the rest-frame distance and the contracted distance side by side
 - **Relativistic rocket equation** — used to compute fuel mass for a 1-tonne ship
 
 ## 3D visualisation
@@ -30,7 +35,7 @@ The simulator models a symmetric three-phase journey — accelerate at constant 
 
 ## Fuel calculator
 
-Fuel requirements are computed for two drive types: a theoretical perfect matter–antimatter engine (exhaust velocity = c) and conventional chemical rockets (I_sp ≈ 450 s). For relativistic speeds, chemical fuel mass quickly exceeds the mass of the observable universe, which the UI notes explicitly.
+Fuel requirements are computed for two drive types: an ideal photon rocket (perfectly directed radiation exhaust at c, without conversion losses) and conventional chemical rockets (I_sp ≈ 450 s). For relativistic speeds, chemical fuel mass quickly exceeds the mass of the observable universe, which the UI notes explicitly.
   `.trim(),
 }
 

--- a/src/content/projects/teslacode.ts
+++ b/src/content/projects/teslacode.ts
@@ -10,6 +10,10 @@ const project: ProjectMeta = {
   longDescription: `
 Real-time screen sharing from a Mac to a Tesla's built-in browser. The goal: keep working — primarily **coding with Claude Code** — from the car while parked or charging, eyes-up and hands-free.
 
+WebRTC connects browser peers; a DataChannel carries arbitrary bytes. Signalling
+exchanges connection details, while a TURN relay may forward encrypted traffic when
+a direct connection is unavailable.
+
 ## The Tesla constraint
 
 Tesla blocks \`<video>\` playback in its browser while the car is in use, so a normal WebRTC video stream is a dead end. Instead, the Mac captures the screen with \`getDisplayMedia()\`, draws each frame to an offscreen canvas, encodes it as a JPEG, and ships the raw bytes over a WebRTC DataChannel. The Tesla renders each frame into an \`<img>\` element — which Tesla doesn't block. Frame rate adapts to connection quality.
@@ -20,11 +24,13 @@ Mac → getDisplayMedia() → canvas → JPEG → DataChannel → Tesla <img>
                            Server (Hono/WS)
 \`\`\`
 
-The server only brokers the WebRTC handshake; once connected, frames flow peer-to-peer (or via a TURN relay when the car's network requires it — Tesla's in-car connectivity always does).
+The server only brokers the WebRTC handshake; once connected, frames flow peer-to-peer (or via a TURN relay when the car's network requires it — depending on network conditions).
 
 ## Hands-free controls
 
-Mic and Send buttons on the Tesla viewer send keystrokes back to the Mac, so you can drive a voice-mode Claude Code session entirely from the car's touchscreen. A small local daemon (\`npx teslacode.dev\`) receives the commands and synthesises the keystrokes — key events travel Tesla → DataChannel → share page → local daemon, never through the server.
+Mic and Send buttons on the Tesla viewer send keystrokes back to the Mac, so you can drive a voice-mode Claude Code session entirely from the car's touchscreen. A small local daemon (\`npx teslacode.dev\`) receives the commands and synthesises the keystrokes — key events travel Tesla → DataChannel → share page → local daemon, outside the signalling service’s application-message path; encrypted traffic may
+still pass through a TURN relay. Input authorization also depends on pairing and
+the trusted app/daemon, not just the transport.
 
 ## Product
 

--- a/src/content/projects/webgpu-md.ts
+++ b/src/content/projects/webgpu-md.ts
@@ -9,11 +9,16 @@ const project: ProjectMeta = {
   repoUrl: 'https://github.com/andeplane/webgpu-md',
   screenshot: '/projects/webgpu-md/preview.png',
   longDescription: `
-A high-performance molecular dynamics engine that runs entirely in the browser using WebGPU compute shaders. No server, no native app — just open the page and simulate up to 2 million Lennard-Jones atoms at interactive framerates.
+A high-performance molecular dynamics engine that runs entirely in the browser using WebGPU compute shaders. No server, no native app — the model runs locally. Molecular dynamics advances particle positions using forces
+and Newton’s laws. Lennard-Jones particles use a simple pair energy with short-range
+repulsion and longer-range attraction; they are a model system, not every kind of atom.
+Reported million-particle runs depend on GPU, density, cutoff and steps per frame.
+Use the scaling benchmark to measure a particular device.
 
 ## Why WebGPU?
 
-Previous browser-based MD simulations were limited by WebGL's lack of compute shaders. WebGPU exposes the GPU's compute pipeline, making it possible to implement the full MD force-calculation loop — neighbour lists, pair interactions, Verlet integration — as GPU kernels written in WGSL. The result is 10–50× faster than a JavaScript implementation of the same algorithm.
+Previous browser-based MD simulations were limited by WebGL's lack of compute shaders. WebGPU exposes the GPU's compute pipeline, making it possible to implement the full MD force-calculation loop — neighbour lists, pair interactions, Verlet integration — as GPU kernels written in WGSL. The speedup depends on hardware and workload; a useful comparison must hold particle
+count, density, cutoff, precision and simulated steps fixed.
 
 ## Pipeline
 
@@ -24,13 +29,13 @@ Every step of the simulation runs on the GPU:
 3. **Velocity Verlet integration** — positions and velocities updated; periodic boundary conditions applied
 4. **Kinetic energy reduction** — tree reduction on the GPU computes instantaneous temperature
 
-The final atom positions buffer is read directly by the WebGPU render pipeline (zero CPU readback), so rendering adds almost no overhead.
+The final atom positions buffer is read directly by the WebGPU render pipeline (zero CPU readback), avoiding a position transfer each frame. Rendering itself still has a cost.
 
 ## Features
 
 - Simulate 4K → 4M atoms with built-in scaling benchmark
 - SSAO post-processing for depth perception
-- Play/pause, step, reset; adjustable temperature, density, and atoms per frame
+- Play/pause, step, reset; adjustable temperature, density, and simulation steps per frame
 - LAMMPS data file import for custom initial configurations
 - Extensible pair style system for adding new force fields
   `.trim(),

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -32,7 +32,7 @@ export default function About() {
           </p>
 
           <p>
-            Outside of simulations I build games (a curling simulator with a real friction model, a tower defence game with pathfinding AI), developer tools, and occasional experiments with LLMs. I'm particularly interested in the Claude API and what becomes possible when you combine language models with structured data and domain knowledge.
+            Outside of simulations I build games (a curling simulator with a model of friction and curl, a tower defence game with an economic AI opponent), developer tools, and occasional experiments with LLMs. I'm particularly interested in the Claude API and what becomes possible when you combine language models with structured data and domain knowledge.
           </p>
 
           <p>

--- a/src/pages/Interests.tsx
+++ b/src/pages/Interests.tsx
@@ -29,8 +29,8 @@ export default function Interests() {
             Neural operators <span>↗</span>
           </h2>
           <p>
-            From integral kernels and Fourier layers to sparse computation, physical simulation and
-            robotics.
+            Learning maps between whole fields — such as temperature now and after heat spreads —
+            with interactive concepts, physical simulations and a literature graph.
           </p>
           <div className="no-tags">
             <span>Literature graph</span>


### PR DESCRIPTION
Several project pages lead with acronyms and implementation lists rather than the problem or mechanism. Particle Defence contradicts its local blog about AI routing and upgrades. Curling calls a phenomenological game model physics-accurate. Relativity describes contraction as the universe shrinking without specifying frame. AI analytics equates executable generated code with correct analysis, and teslacode overstates what peer-to-peer transport proves about relays and input trust. WebGPU performance claims lack benchmark context.

Introduces project mechanisms before jargon and adds concrete interpretation checks. Reconciles Particle Defence with its local article; scopes curling and relativity models; separates executable AI code from correct analysis; qualifies transport trust and workload-dependent GPU performance. Only this repository’s descriptions and posts were inspected or edited for external projects.

Validation: TypeScript build and diff hygiene; compared project descriptions with their corresponding local posts. External applications and their current implementation were deliberately excluded.


Closes #48
