### PR TITLE
Keep physics explanation buttons clear of control panels

### DIFF
--- a/demos/ising/src/style.css
+++ b/demos/ising/src/style.css
@@ -343,7 +343,7 @@ body {
   left: 1.9rem;
   bottom: 6.4rem;
   width: 17.5rem;
-  max-height: min(calc(100vh - 14rem), 42rem);
+  max-height: min(calc(100dvh - 20rem), 42rem);
   overflow-y: auto;
   overscroll-behavior: contain;
   padding: 0.85rem 0.95rem 1.1rem;
@@ -1120,4 +1120,9 @@ input[type='range']::-moz-range-thumb {
   #mobilebar {
     display: none !important;
   }
+}
+
+/* Leave room for the title and its theory button above mobile readouts. */
+@media (max-width: 760px) {
+  #readouts { top: 7rem; }
 }

--- a/demos/tidal-locking/src/style.css
+++ b/demos/tidal-locking/src/style.css
@@ -205,7 +205,7 @@ body {
   /* Leave the panel a little shorter than the viewport so the fade at its foot is
      visible whenever there is more below -- a list clipped flush at the edge reads as
      the end of the list, and the controls under the fold simply never get found. */
-  max-height: min(calc(100vh - 9rem), 42rem);
+  max-height: min(calc(100dvh - 15rem), 42rem);
   overflow-y: auto;
   overscroll-behavior: contain;
   padding: 0.85rem 0.95rem 1.1rem;
@@ -567,4 +567,9 @@ input[type='range']::-moz-range-thumb {
   #explainer h1 {
     font-size: 1.25rem;
   }
+}
+
+/* Leave room for the title and its theory button above mobile readouts. */
+@media (max-width: 760px) {
+  #readouts { top: 7rem; }
 }


### PR DESCRIPTION
In the compiled site at 1280×720, the Ising control panel covers the How does it work button; hit-testing at the button lands on the controls. Tidal Locking uses the same overlapping title/control layout. On narrow screens the readouts also occupy the title area. This prevents readers reaching the theory.

Reserves title height above the desktop control panels and moves mobile readouts below the title and theory button. This restores the entry point to the educational content without changing simulation behavior.

Validation: reproduced with browser hit-testing on the compiled site; desktop and phone button/dialog checks follow in the combined review. Demo TypeScript/build checks run in CI.


Closes #59
