### PR TITLE
Use consistent interval labels and explain enharmonic spellings

### DIFF
--- a/demos/interval-trainer/README.md
+++ b/demos/interval-trainer/README.md
@@ -2,7 +2,7 @@
 
 Ear training for musical intervals. Every question sounds the root and its fifth
 *together* to establish a key, then one more note; you name where that note sits — `3` or
-`3b`, `7` or `7b`. Practice mode has no clock and tracks which intervals you keep missing;
+`♭3`, `7` or `♭7`. Practice mode has no clock and tracks which intervals you keep missing;
 game mode runs a two-minute clock that correct answers extend.
 
 ```
@@ -19,7 +19,8 @@ silent for screenshotting. `?canvas2d` forces the wave field's fallback renderer
 
 - **Ten answers, never the root or the fifth** — those two are given away by the chord.
   `src/core/intervals.ts` holds all twelve degrees and the ten askable ones, labelled with
-  the accidental after the number (`3b`, `7b`) and the tritone written `4#`.
+  the accidental before the number (`♭3`, `♭7`) and the tritone written `♭5`.
+  The tutorial explains enharmonic alternatives, including ♯4 = ♭5 and ♯5 = ♭6.
 - **Three difficulties** (`src/core/difficulty.ts`), two dials between them: which degrees
   can be asked, and whether the key moves. *Easy* holds one key for the whole run and asks
   only the five degrees written without a flat or a sharp — a five-key pad, shortcuts

--- a/demos/interval-trainer/src/core/difficulty.ts
+++ b/demos/interval-trainer/src/core/difficulty.ts
@@ -20,7 +20,7 @@ export const DIFFICULTY_ORDER: readonly Difficulty[] = ['easy', 'medium', 'hard'
 
 /** The degrees written without a flat or a sharp: 2, 3, 4, 6, 7. */
 export const NATURAL_SEMITONES: readonly number[] = ANSWERS.filter(
-  (interval) => !/[b#]/.test(interval.label),
+  (interval) => [2, 4, 5, 9, 11].includes(interval.semitones),
 ).map((interval) => interval.semitones);
 
 export const ALL_SEMITONES: readonly number[] = ANSWERS.map((interval) => interval.semitones);

--- a/demos/interval-trainer/src/core/intervals.test.ts
+++ b/demos/interval-trainer/src/core/intervals.test.ts
@@ -7,19 +7,19 @@ describe('intervals', () => {
     expect(INTERVALS.map((i) => i.semitones)).toEqual([...Array(12).keys()]);
   });
 
-  it('labels flats after the number, and the tritone as 4#', () => {
+  it('labels altered degrees with a leading flat, including the tritone', () => {
     expect(INTERVALS.map((i) => i.label)).toEqual([
       '1',
-      '2b',
+      '♭2',
       '2',
-      '3b',
+      '♭3',
       '3',
       '4',
-      '4#',
+      '♭5',
       '5',
-      '6b',
+      '♭6',
       '6',
-      '7b',
+      '♭7',
       '7',
     ]);
   });

--- a/demos/interval-trainer/src/core/intervals.ts
+++ b/demos/interval-trainer/src/core/intervals.ts
@@ -1,8 +1,8 @@
 /**
  * The interval vocabulary of the app.
  *
- * Labels use the notation this trainer is built around: the accidental comes *after* the
- * number (`3b`, `7b`), and the tritone is written `4#` rather than `5b`.
+ * Labels put the accidental before the degree (`♭3`, `♭7`). Altered degrees use
+ * flats consistently; the tutorial explains enharmonic spellings such as ♯4 and ♯5.
  *
  * Every question opens with the root and its fifth sounded together, so those two are
  * never the answer — `ANSWERS` is the remaining ten, and it is what the keypad renders.
@@ -11,7 +11,7 @@
 export interface Interval {
   /** Semitones above the root, 0-11. */
   semitones: number;
-  /** Button label, e.g. `3b`. */
+  /** Button label, e.g. `♭3`. */
   label: string;
   /** Spoken name, used for aria-labels and the tutorial. */
   name: string;
@@ -22,16 +22,16 @@ export interface Interval {
 /** All twelve degrees of the octave, indexed by semitone. */
 export const INTERVALS: readonly Interval[] = [
   { semitones: 0, label: '1', name: 'root', short: 'root' },
-  { semitones: 1, label: '2b', name: 'minor second', short: 'min 2nd' },
+  { semitones: 1, label: '♭2', name: 'minor second', short: 'min 2nd' },
   { semitones: 2, label: '2', name: 'major second', short: 'maj 2nd' },
-  { semitones: 3, label: '3b', name: 'minor third', short: 'min 3rd' },
+  { semitones: 3, label: '♭3', name: 'minor third', short: 'min 3rd' },
   { semitones: 4, label: '3', name: 'major third', short: 'maj 3rd' },
   { semitones: 5, label: '4', name: 'perfect fourth', short: 'fourth' },
-  { semitones: 6, label: '4#', name: 'tritone', short: 'tritone' },
+  { semitones: 6, label: '♭5', name: 'tritone', short: 'tritone' },
   { semitones: 7, label: '5', name: 'perfect fifth', short: 'fifth' },
-  { semitones: 8, label: '6b', name: 'minor sixth', short: 'min 6th' },
+  { semitones: 8, label: '♭6', name: 'minor sixth', short: 'min 6th' },
   { semitones: 9, label: '6', name: 'major sixth', short: 'maj 6th' },
-  { semitones: 10, label: '7b', name: 'minor seventh', short: 'min 7th' },
+  { semitones: 10, label: '♭7', name: 'minor seventh', short: 'min 7th' },
   { semitones: 11, label: '7', name: 'major seventh', short: 'maj 7th' },
 ];
 
@@ -45,7 +45,7 @@ export const ANSWERS: readonly Interval[] = INTERVALS.filter(
 
 /**
  * Keyboard shortcuts, positional: the number row maps onto the keypad in reading order,
- * so key `1` is the leftmost button (`2b`) and key `0` is the last (`7`).
+ * so key `1` is the leftmost button (`♭2`) and key `0` is the last (`7`).
  */
 export const ANSWER_KEYS = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0'] as const;
 

--- a/demos/interval-trainer/src/ui/menu.ts
+++ b/demos/interval-trainer/src/ui/menu.ts
@@ -22,8 +22,8 @@ export function buildMenu(
     title('Name the note'),
     para(
       'Every question sounds the <b>root and its fifth together</b> to set the key, then ' +
-        'one more note. Say where that note sits: <b>3</b> or <b>3b</b>, <b>7</b> or ' +
-        '<b>7b</b>.',
+        'one more note. Say where that note sits: <b>3</b> or <b>♭3</b>, <b>7</b> or ' +
+        '<b>♭7</b>.',
     ),
     difficultyPicker(info.difficulty, handlers.onDifficulty),
     difficultyLegend(info.difficulty),

--- a/demos/interval-trainer/src/ui/tutorial.ts
+++ b/demos/interval-trainer/src/ui/tutorial.ts
@@ -143,10 +143,16 @@ export class Tutorial {
         `Count the major scale from the root: C, D, E, F, G are <b>1, 2, 3, 4, 5</b>.
 A degree is not a semitone count: C to E is degree 3 but spans four piano-key steps.
 A <b>semitone</b> is one adjacent key, including black keys; twelve make an octave.
-With C as root, <b>3</b> is E and <b>3b</b> is E-flat. <b>b</b> after a degree means ` +
-          'a semitone lower: <b>3</b> is the bright major third, <b>3b</b> the darker ' +
-          'minor one. <b>4#</b> is the restless one halfway up (some write it <b>5b</b>). ' +
-          'The root and fifth are not here — the opening chord gives you those for free.',
+With C as root, <b>3</b> is E and <b>♭3</b> is E-flat. A <b>♭</b> before a degree
+means one semitone lower; <b>♯</b> means one semitone higher.
+The <b>♭5</b>, or <b>tritone</b>, is six semitones above the root.
+The root and perfect fifth are not here — the opening chord gives you those for free.`,
+      ),
+      para(
+        `Different spellings can name the same pitch in this equal-tempered tuning:
+<b>♭2 = ♯1</b>, <b>♭3 = ♯2</b>, <b>♭5 = ♯4</b>, <b>♭6 = ♯5</b> and <b>♭7 = ♯6</b>.
+These are called <b>enharmonic</b> spellings. Musical context determines which spelling fits;
+this listening game uses one flat label per altered pitch, so there is no extra answer to learn.`,
       ),
       grid,
       readout,

--- a/src/content/blog/a-perfect-fifth-you-can-see.md
+++ b/src/content/blog/a-perfect-fifth-you-can-see.md
@@ -18,8 +18,8 @@ C–D–E–F–G–A–B are degrees 1–7: E is degree 3 and G is degree 5. A 
 not a count of semitones. A **semitone** is the step to the adjacent piano key,
 including black keys; C to E spans four, while C to G spans seven.
 
-Here `3b` means lower degree 3 by one semitone: E-flat when C is home. `4#` means
-raise degree 4: F-sharp. The octave is the next C, twelve semitones above the root.
+Here `♭3` means lower degree 3 by one semitone: E-flat when C is home. `♭5` means
+lower degree 5: G-flat, the six-semitone tritone. The octave is the next C, twelve semitones above the root.
 Try singing C–D–E, then compare C–E with C–E-flat before using the keypad.
 
 ## Two sounds, not three
@@ -33,11 +33,11 @@ One second of an open fifth to tell your ear where home is, then the note you ha
 That choice pays a second dividend. If the opening chord hands you `1` and `5` for free, they can never be the answer, and the keypad drops from twelve buttons to ten:
 
 ```
-2b  2  3b  3  4  4#
-6b  6  7b  7
+♭2  2  ♭3  3  4  ♭5
+♭6  6  ♭7  7
 ```
 
-The accidental goes *after* the number, which is how I think when I'm counting degrees, and the tritone is `4#` rather than `5b` — the fifth is the fifth, and it is already in the chord.
+The accidental goes **before** the number. I use flat labels consistently for the altered degrees. In equal temperament, `♭2 = ♯1`, `♭3 = ♯2`, `♭5 = ♯4`, `♭6 = ♯5` and `♭7 = ♯6`: these are **enharmonic** spellings of the same pitches. Musical context determines the spelling, but this game asks you to recognise a sound relative to the root. Each pitch therefore has one answer button. The perfect fifth (`5`, seven semitones) is in the opening chord; the tritone (`♭5`, six semitones) is still an answer.
 
 ## What actually makes it hard
 

--- a/src/content/projects/interval-trainer.ts
+++ b/src/content/projects/interval-trainer.ts
@@ -15,7 +15,7 @@ times, which means the practice has to be quick, honest, and pleasant enough to 
 to. Every question here opens the same way — the root and the fifth above it struck
 together, an open chord that tells your ear where *home* is — and then plays one more
 note. You say where it landed: **3** or
-**3b**, **7** or **7b**, ten buttons, ten keyboard shortcuts, no menus in between.
+**♭3**, **7** or **♭7**, ten buttons, ten keyboard shortcuts, no menus in between.
 
 ## What you can do
 
@@ -27,7 +27,7 @@ nothing carries over from the last one. Each keeps its own highscore board.
 Practice with no clock at all: replay a question as many times as you like, get the answer
 named the moment you commit to it, and hear a miss played back to you with the right
 answer on screen. A strip along the bottom keeps score per interval, so the vague feeling
-that you are bad at **6b** turns into a bar you can watch climb.
+that you are bad at **♭6** turns into a bar you can watch climb.
 
 Or play it as a game. Two minutes on the clock, six more seconds for every correct answer
 — you watch them fly up from the note that earned them — and a hundred points plus a
@@ -46,7 +46,7 @@ equal-tempered fifth is close to, but not exactly, a 3:2 frequency ratio.
 The sources add as signed waves at a slowed visual scale. This is an illustration of
 superposition, not a physical recording of the piano sound or a test of consonance.
 Start in Easy practice, keep one root, and compare a third with a fourth. Then try
-Medium to hear the major third (3) beside the minor third (3b).
+Medium to hear the major third (3) beside the minor third (♭3).
 
 ## Under the hood
 

--- a/src/pages/Music.tsx
+++ b/src/pages/Music.tsx
@@ -84,7 +84,7 @@ export default function Music() {
           frequency doubles. A semitone is one step between adjacent piano keys,
           including the black keys, and twelve semitones make an octave.</p>
         <p>In the trainer, listen to C and G together, then compare E with E-flat.
-          E is the major third, labelled 3; E-flat is one semitone lower, labelled 3b.
+          E is the major third, labelled 3; E-flat is one semitone lower, labelled ♭3.
           Start in Easy practice, then switch to Medium to include altered notes such as E-flat. Replay before answering. The aim is to recognise
           each note’s relationship to home, even when home changes.</p>
         <p>In the tube lab, watch the pressure rather than a travelling parcel of air.


### PR DESCRIPTION
Use leading flat symbols consistently for altered answer degrees: ♭2, ♭3, ♭5, ♭6 and ♭7. The tutorial explains all five enharmonic sharp spellings, including ♯4 = ♭5 and ♯5 = ♭6, and why each pitch has one answer button. Align onboarding, the Music page, project description, article and README.

Easy difficulty now selects its five pitches by semitone value rather than parsing display labels, preserving the existing questions as notation changes.

Validation: all 53 trainer tests pass; trainer production build and site TypeScript check pass. Checked the compiled tutorial in the browser: all ten labels and enharmonic examples render correctly, and Easy retains five answer buttons. Reviewed the final diff for label consistency and unchanged pitch/scoring behavior.
